### PR TITLE
ci: add docker release workflow to build and release docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -44,4 +44,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
+          cache-from: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache
+          cache-to: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache,mode=max
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,47 @@
+name: DockerImage build and push
+
+on:
+  push:
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+jobs:
+  # Push image to GitHub Packages.
+  push-op-geth:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: ImageId
+        id: image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/op-geth
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo "IMAGE_ID=$IMAGE_ID">>$GITHUB_OUTPUT
+          echo "VERSION=$VERSION">>$GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
+


### PR DESCRIPTION
add the ci code used to package and release docker images

Execution effect:
![image](https://github.com/bnb-chain/op-geth/assets/136572398/d7d2f187-7030-4060-aa78-af3626081179)
![image](https://github.com/bnb-chain/op-geth/assets/136572398/47baf429-7503-4fdb-a048-16de1e182b7c)
Note:
Need to open the write permission of github_token, path: settings->Actions->General->Workflow permissions
![image](https://user-images.githubusercontent.com/136572398/247019933-30023ab0-fa32-40f3-9319-f5636c873fe9.png)