### PR TITLE
feat: add preDeployedContract hardfork

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -162,6 +162,10 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		misc.ApplyDAOHardFork(statedb)
 	}
 
+	if chainConfig.PreContractForkBlock != nil && chainConfig.PreContractForkBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
+		misc.ApplyPreContractHardFork(statedb)
+	}
+
 	for i, tx := range txs {
 		msg, err := core.TransactionToMessage(tx, signer, pre.Env.BaseFee)
 		if err != nil {

--- a/consensus/misc/precontract.go
+++ b/consensus/misc/precontract.go
@@ -1,0 +1,42 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package misc
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
+)
+
+var (
+	// WBNBContract WBNB preDeploy contract address
+	WBNBContract = common.HexToAddress("0x4200000000000000000000000000000000000006")
+	// GovernanceToken contract address
+	governanceToken = common.HexToAddress("4200000000000000000000000000000000000042")
+	nameSlot        = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000")
+	symbolSlot      = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
+	// Wrapped BNB
+	nameValue = common.HexToHash("0x5772617070656420424e42000000000000000000000000000000000000000016")
+	// WBNB
+	symbolValue = common.HexToHash("0x57424e4200000000000000000000000000000000000000000000000000000008")
+)
+
+// ApplyPreContractHardFork modifies the state database according to the hard-fork rules
+func ApplyPreContractHardFork(statedb *state.StateDB) {
+	statedb.SetState(WBNBContract, nameSlot, nameValue)
+	statedb.SetState(WBNBContract, symbolSlot, symbolValue)
+	statedb.Suicide(governanceToken)
+}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -310,6 +310,9 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		if config.DAOForkSupport && config.DAOForkBlock != nil && config.DAOForkBlock.Cmp(b.header.Number) == 0 {
 			misc.ApplyDAOHardFork(statedb)
 		}
+		if config.PreContractForkBlock != nil && config.PreContractForkBlock.Cmp(b.header.Number) == 0 {
+			misc.ApplyPreContractHardFork(statedb)
+		}
 		// Execute any user modifications to the block
 		if gen != nil {
 			gen(i, b)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -70,6 +70,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
+	if p.config.PreContractForkBlock != nil && p.config.PreContractForkBlock.Cmp(block.Number()) == 0 {
+		misc.ApplyPreContractHardFork(statedb)
+	}
 	blockContext := NewEVMBlockContext(header, p.bc, nil, p.config, statedb)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 	// Iterate over and process the individual transactions

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1176,6 +1176,10 @@ func (w *worker) generateWork(genParams *generateParams) (*types.Block, *big.Int
 		return nil, nil, nil, err
 	}
 	defer work.discard()
+
+	if w.chainConfig.PreContractForkBlock != nil && work.header.Number.Cmp(w.chainConfig.PreContractForkBlock) == 0 {
+		misc.ApplyPreContractHardFork(work.state)
+	}
 	if work.gasPool == nil {
 		work.gasPool = new(core.GasPool).AddGas(work.header.GasLimit)
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -476,6 +476,8 @@ type ChainConfig struct {
 
 	// Optimism config, nil if not active
 	Optimism *OptimismConfig `json:"optimism,omitempty"`
+	// PreContractForkBlock hard-fork switch block (nil = no fork, 0 = already on preContractForkBlock)
+	PreContractForkBlock *big.Int `json:"preContractForkBlock,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -598,6 +600,9 @@ func (c *ChainConfig) Description() string {
 	}
 	if c.RegolithTime != nil {
 		banner += fmt.Sprintf(" - Regolith:                    @%-10v\n", *c.RegolithTime)
+	}
+	if c.PreContractForkBlock != nil {
+		banner += fmt.Sprintf(" - PreContractForkBlock:        @%-10v\n", *c.PreContractForkBlock)
 	}
 	return banner
 }
@@ -1028,12 +1033,12 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID                                                 *big.Int
-	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
-	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	IsBerlin, IsLondon                                      bool
-	IsMerge, IsShanghai, isCancun, isPrague                 bool
-	IsOptimismBedrock, IsOptimismRegolith                   bool
+	ChainID                                                   *big.Int
+	IsHomestead, IsEIP150, IsEIP155, IsEIP158                 bool
+	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul   bool
+	IsBerlin, IsLondon                                        bool
+	IsMerge, IsShanghai, isCancun, isPrague                   bool
+	IsOptimismBedrock, IsOptimismRegolith, IsPreContractBlock bool
 }
 
 // Rules ensures c's ChainID is not nil.

--- a/params/config.go
+++ b/params/config.go
@@ -1033,12 +1033,12 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID                                                   *big.Int
-	IsHomestead, IsEIP150, IsEIP155, IsEIP158                 bool
-	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul   bool
-	IsBerlin, IsLondon                                        bool
-	IsMerge, IsShanghai, isCancun, isPrague                   bool
-	IsOptimismBedrock, IsOptimismRegolith, IsPreContractBlock bool
+	ChainID                                                 *big.Int
+	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
+	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
+	IsBerlin, IsLondon                                      bool
+	IsMerge, IsShanghai, isCancun, isPrague                 bool
+	IsOptimismBedrock, IsOptimismRegolith                   bool
 }
 
 // Rules ensures c's ChainID is not nil.


### PR DESCRIPTION
### Description

This feature is add preDeployedContract hardfork to change preDeployed contract `WBNB` `name` and `symbol`, and remove preDeployed contract GovernanceToken.

### Rationale

The preDeployed contract `WBNB` address is `0x4200000000000000000000000000000000000006` , `name` and `symbol` is not correct, so it should be changed to `Wrapped BNB` and `WBNB`. And `OP-BNB` doesn't need GovernanceToken,
so the preDeployed contract `4200000000000000000000000000000000000042` should be removed.

### Changes
Set preDeployed contract `WBNB` `name` to `Wrapped BNB`.
Set preDeployed contract `WBNB` `symbol` to `WBNB`.
Remove preDeployed contract `4200000000000000000000000000000000000042`

