### PR TITLE
feat: support snap sync for OP chains

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -169,9 +169,9 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 	} else {
 		blockNumber := h.chain.CurrentBlock().Number
-		// [Optimism] Allow snap sync from bedrock genesis block
-		if blockNumber.Uint64() > 0 && blockNumber.Cmp(config.Chain.Config().BedrockBlock) != 0 {
+		if blockNumber.Uint64() > 0 && (!config.Chain.Config().IsOptimism() || blockNumber.Cmp(config.Chain.Config().BedrockBlock) != 0) {
 			// Print warning log if database is not empty to run snap sync.
+			// For OP chains, snap sync from bedrock block is allowed.
 			log.Warn("Switch sync mode from snap sync to full sync")
 		} else {
 			// If snap sync was requested and our database is empty, grant it

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -168,7 +168,9 @@ func newHandler(config *handlerConfig) (*handler, error) {
 			log.Warn("Switch sync mode from full sync to snap sync")
 		}
 	} else {
-		if h.chain.CurrentBlock().Number.Uint64() > 0 {
+		blockNumber := h.chain.CurrentBlock().Number
+		// [Optimism] Allow snap sync from bedrock genesis block
+		if blockNumber.Uint64() > 0 && blockNumber.Cmp(config.Chain.Config().BedrockBlock) != 0 {
 			// Print warning log if database is not empty to run snap sync.
 			log.Warn("Switch sync mode from snap sync to full sync")
 		} else {

--- a/eth/protocols/snap/handler.go
+++ b/eth/protocols/snap/handler.go
@@ -469,7 +469,7 @@ func ServiceGetByteCodesQuery(chain *core.BlockChain, req *GetByteCodesPacket) [
 			// Peers should not request the empty code, but if they do, at
 			// least sent them back a correct response without db lookups
 			codes = append(codes, []byte{})
-		} else if blob, err := chain.ContractCodeWithPrefix(hash); err == nil {
+		} else if blob, err := chain.ContractCode(hash); err == nil {
 			codes = append(codes, blob)
 			bytes += uint64(len(blob))
 		}


### PR DESCRIPTION

**Description**
This feature is related to [PR #105](https://github.com/ethereum-optimism/op-geth/pull/105). 

**Rationale**
It's a small fix for Geth’s snap sync for op chains.

**Example**
NA

**Changes**
1.  adds a fallback logic for the legacy keys to serve bytecodes for snap sync