### PR TITLE
ci: refactor docker release workflow and image metadata

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,16 +1,17 @@
 name: DockerImage build and push
 
 on:
+  workflow_dispatch:
   push:
-    # Publish `v1.2.3` tags as releases.
+    branches:
+      - develop
+      - main
     tags:
-      - v*
 
 jobs:
   # Push image to GitHub Packages.
   push-op-geth:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v3
@@ -22,28 +23,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: ImageId
-        id: image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/op-geth
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-          echo "IMAGE_ID=$IMAGE_ID">>$GITHUB_OUTPUT
-          echo "VERSION=$VERSION">>$GITHUB_OUTPUT
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: image meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/op-geth
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.image.outputs.IMAGE_ID }}:${{ steps.image.outputs.VERSION }},${{ steps.image.outputs.IMAGE_ID }}:latest
-          cache-from: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache
-          cache-to: type=registry,ref=${{ steps.image.outputs.IMAGE_ID }}:buildcache,mode=max
-
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -23,12 +23,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to GHCR
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: image meta
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - develop
       - main
-    tags:
+    tags: '*'
 
 jobs:
   # Push image to GitHub Packages.


### PR DESCRIPTION
### Description

Refactor Docker release workflow and image metadata.

### Rationale

Previously, the Docker release workflow built and published the Docker image only when a `v*` tag was pushed. However, we now have additional scenarios where we need the Docker image, such as deploying and testing a specific feature before its release. Therefore, we have added more conditions that will trigger the building of Docker images.

### Example

Events and the associated docker tags

Event | Ref | Docker Tags
-- | -- | --
push | refs/heads/main | main
push | refs/heads/develop | develop
push tag | refs/tags/v1.2.3 | v1.2.3, 1.2.3
push tag | refs/tags/v2.0.8-beta.67 | v2.0.8-beta.67, 2.0.8-beta.67
workflow_dispatch | refs/heads/main | main

A tag associated with the given git commit hash like `sha-ad132f5` will also be added.

### Changes

Notable changes:
* Modified the trigger conditions.
* Included additional tags and metadata.
* Eliminated the cache configuration as it provides minimal assistance for multi-stage Docker builds.