### PR TITLE
fix: wrong event log value[BNB-8]

### DIFF
--- a/core/state/pruner/pruner.go
+++ b/core/state/pruner/pruner.go
@@ -315,7 +315,7 @@ func (p *Pruner) Prune(root common.Hash) error {
 		}
 	} else {
 		if len(layers) > 0 {
-			log.Info("Selecting bottom-most difflayer as the pruning target", "root", root, "height", p.chainHeader.Number.Uint64()-127)
+			log.Info("Selecting bottom-most difflayer as the pruning target", "root", root, "height", p.chainHeader.Number.Uint64()-(p.triesInMemory-1))
 		} else {
 			log.Info("Selecting user-specified state as the pruning target", "root", root)
 		}


### PR DESCRIPTION
### Description
This message is not updated to reflect the optimization of TriesInMemory diff layers. Currently, the number is variable and not fixed at 128.

### Rationale

fix wrong event log value

### Example

none

### Changes

- fix wrong log value