### PR TITLE
fix: bubbling up the error when DeriveField() fails[BNB-13]

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1869,11 +1869,14 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 		proctime := time.Since(start) // processing + validation
 
 		// pre-cache the block and receipts, so that it can be retrieved quickly by rcp
-		bc.CacheBlock(block.Hash(), block)
 		err = types.Receipts(receipts).DeriveFields(bc.chainConfig, block.Hash(), block.NumberU64(), block.Time(), block.BaseFee(), block.Transactions())
 		if err != nil {
 			log.Warn("Failed to derive receipt fields", "block", block.Hash(), "err", err)
+			bc.reportBlock(block, receipts, err)
+			close(interruptCh)
+			return it.index, err
 		}
+		bc.CacheBlock(block.Hash(), block)
 		bc.CacheReceipts(block.Hash(), receipts)
 
 		// Update the metrics touched during block processing and validation


### PR DESCRIPTION
### Description
bubbling up the error when DeriveField() fails.

### Rationale
In `blockchain.go:insertChain()`, the `types.Receipts(receipts).DeriveField()` call can potentially return an error. In the case that the `DeiveField()` fails, the receipts will not have the expected data attached to it. However, the code caches the block data ( `CacheBlock()` ) and the receipt data ( `CacheReceipts()` ) no matter whether the `DeriveField()` errors out or not in the `insertChain()` function. Incomplete or invalid data can be cached and risk causing unexpected scenario.

### Example
none

### Changes

Notable changes:
* bubbling up the error when DeriveField() fails.
* bc.reportBlock and close(interruptCh) is the aftermath work that must be included