### PR TITLE
fix: refraining from using gopool for long-running tasks[BNB-19]

### DIFF
--- a/eth/bloombits.go
+++ b/eth/bloombits.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/bitutil"
-	"github.com/ethereum/go-ethereum/common/gopool"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 )
 
@@ -46,7 +45,7 @@ const (
 // retrievals from possibly a range of filters and serving the data to satisfy.
 func (eth *Ethereum) startBloomHandlers(sectionSize uint64) {
 	for i := 0; i < bloomServiceThreads; i++ {
-		gopool.Submit(func() {
+		go func() {
 			for {
 				select {
 				case <-eth.closeBloomHandler:
@@ -70,6 +69,6 @@ func (eth *Ethereum) startBloomHandlers(sectionSize uint64) {
 					request <- task
 				}
 			}
-		})
+		}()
 	}
 }

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -178,8 +178,8 @@ func newDialScheduler(config dialConfig, it enode.Iterator, setupFunc dialSetupF
 	d.lastStatsLog = d.clock.Now()
 	d.ctx, d.cancel = context.WithCancel(context.Background())
 	d.wg.Add(2)
-	gopool.Submit(func() { d.readNodes(it) })
-	gopool.Submit(func() { d.loop(it) })
+	go func() { d.readNodes(it) }()
+	go func() { d.loop(it) }()
 	return d
 }
 


### PR DESCRIPTION
### Description

Use `go` to run long-running tasks instead of gopool

### Rationale

The gopool limits the go-routines to run at a time, keeping the total go-routine memory in a manageable state.
However, for a long-running task, it will occupy a worker from the pool and never return, causing the effective pool size to decrease. 

### Example
none

### Changes

Notable changes:
* Use `go` to run long-running tasks instead of gopool