### PR TITLE
fix: remove redundant lock[BNB-20]

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -227,7 +227,6 @@ type BlockChain struct {
 	quit          chan struct{}  // shutdown signal, closed in Stop.
 	running       int32          // 0 if chain is running, 1 when stopped
 	procInterrupt int32          // interrupt signaler for block processing
-	commitLock    sync.Mutex     // CommitLock is used to protect above field from being modified concurrently
 
 	engine     consensus.Engine
 	validator  Validator // Block and state validator interface
@@ -1395,8 +1394,6 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 
 	postCommitFuncs := []func() error{
 		func() error {
-			bc.commitLock.Lock()
-			defer bc.commitLock.Unlock()
 
 			root := block.Root()
 			// If we're running an archive node, always flush


### PR DESCRIPTION
### Description

remove commitLock in BlockChain struct

### Rationale

In the `blockchain.go:writeBlockWithState()` function, the first function of the `postCommitFuncs` uses the `bc.commitLock` . However, this lock appears unnecessary, as it is only used for this function and the function concludes after `state.Commit()` . We have not identified any specific data that require this lock.

### Example

none

### Changes

Notable changes:
* remove commitLock in BlockChain struct