### PR TITLE
fix: allow a previously underpriced transaction back in after a timeout 

### DIFF
--- a/eth/fetcher/tx_fetcher.go
+++ b/eth/fetcher/tx_fetcher.go
@@ -54,8 +54,9 @@ const (
 	// re-request them.
 	maxTxUnderpricedSetSize = 32768
 
-	// maxTxUnderpricedTimeout is the max time a transaction should be stuck in the underpriced set.
-	maxTxUnderpricedTimeout = int64(5 * time.Minute)
+	// maxTxUnderpricedTimeout is the max time a transaction should be stuck in the underpriced set
+	// set as 5 minutes.
+	maxTxUnderpricedTimeout = 300
 
 	// txArriveTimeout is the time allowance before an announced transaction is
 	// explicitly requested.

--- a/eth/fetcher/tx_fetcher_test.go
+++ b/eth/fetcher/tx_fetcher_test.go
@@ -1509,8 +1509,8 @@ func testTransactionFetcher(t *testing.T, tt txFetcherTest) {
 			}
 
 		case isUnderpriced:
-			if fetcher.underpriced.Cardinality() != int(step) {
-				t.Errorf("step %d: underpriced set size mismatch: have %d, want %d", i, fetcher.underpriced.Cardinality(), step)
+			if fetcher.underpriced.Len() != int(step) {
+				t.Errorf("step %d: underpriced set size mismatch: have %d, want %d", i, fetcher.underpriced.Len(), step)
 			}
 
 		default:


### PR DESCRIPTION
This issue had been reported to official repo in go-ethereum, here is it [#28018](https://github.com/ethereum/go-ethereum/issues/28018).
And the fix solution had been adopted by official team, with the merged pr [#28097](https://github.com/ethereum/go-ethereum/issues/28018).