### PR TITLE
ci: fix blst error and unknown architecture

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -40,5 +40,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY go.sum /go-ethereum/
 RUN cd /go-ethereum && go mod download
 
 ADD . /go-ethereum
+ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+ENV CGO_CFLAGS_ALLOW="-O -D__BLST_PORTABLE__"
 RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 
 # Pull Geth into a second stage deploy alpine container


### PR DESCRIPTION
### Description

Fix `Caught SIGILL in blst_cgo_init` error in docker image.
Prevent unknown architecture and OS in result.

### Rationale

references
- https://github.com/docker/build-push-action/issues/820
- https://github.com/bnb-chain/bsc/issues/1521
- https://github.com/bnb-chain/bsc/blob/master/Dockerfile

### Example

NA

### Changes

NA
