### PR TITLE
feature: add opBNB bootnodes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1135,7 +1135,13 @@ func setNodeUserIdent(ctx *cli.Context, cfg *node.Config) {
 // setBootstrapNodes creates a list of bootstrap nodes from the command line
 // flags, reverting to pre-configured ones if none have been specified.
 func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
-	urls := params.MainnetBootnodes
+	urls := params.OpBNBMainnetBootnodes
+	if ctx.IsSet(NetworkIdFlag.Name) {
+		networkId := ctx.Uint64(NetworkIdFlag.Name)
+		if networkId == params.OpBNBTestnet {
+			urls = params.OpBNBTestnetBootnodes
+		}
+	}
 	switch {
 	case ctx.IsSet(BootnodesFlag.Name):
 		urls = SplitAndTrim(ctx.String(BootnodesFlag.Name))

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -18,6 +18,8 @@ package params
 
 import "github.com/ethereum/go-ethereum/common"
 
+var OpBNBTestnet uint64 = 5611
+
 // MainnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
 // the main Ethereum network.
 var MainnetBootnodes = []string{
@@ -26,6 +28,22 @@ var MainnetBootnodes = []string{
 	"enode://22a8232c3abc76a16ae9d6c3b164f98775fe226f0917b0ca871128a74a8e9630b458460865bab457221f1d448dd9791d24c4e5d88786180ac185df813a68d4de@3.209.45.79:30303",   // bootnode-aws-us-east-1-001
 	"enode://2b252ab6a1d0f971d9722cb839a42cb81db019ba44c08754628ab4a823487071b5695317c8ccd085219c3a03af063495b2f1da8d18218da2d6a82981b45e6ffc@65.108.70.101:30303", // bootnode-hetzner-hel
 	"enode://4aeb4ab6c14b23e2c4cfdce879c04b0748a20d8e9b59e25ded2a08143e265c6c25936e74cbc8e641e3312ca288673d91f2f93f8e277de3cfa444ecdaaf982052@157.90.35.166:30303", // bootnode-hetzner-fsn
+}
+
+// OpBNBMainnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
+// the opBNB main network.
+var OpBNBMainnetBootnodes = []string{
+	// geth
+	"enr:-KO4QHs5qh_kPFcjMgqkuN9dbxXT4C5Cjad4SAheaUxveCbJQ3XdeMMDHeHilHyqisyYQAByfdhzyKAdUp2SvyzWeBqGAYvRDf80g2V0aMfGhHFtSjqAgmlkgnY0gmlwhDaykUmJc2VjcDI1NmsxoQJUevTL3hJwj21IT2GC6VaNqVQEsJFPtNtO-ld5QTNCfIRzbmFwwIN0Y3CCdl-DdWRwgnZf",
+	"enr:-KO4QKIByq-YMjs6IL2YCNZEmlo3dKWNOy4B6sdqE3gjOrXeKdNbwZZGK_JzT1epqCFs3mujjg2vO1lrZLzLy4Rl7PyGAYvRA8bEg2V0aMfGhHFtSjqAgmlkgnY0gmlwhDbjSM6Jc2VjcDI1NmsxoQNQhJ5pqCPnTbK92gEc2F98y-u1OgZVAI1Msx-UiHezY4RzbmFwwIN0Y3CCdl-DdWRwgnZf",
+}
+
+// OpBNBTestnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
+// the opBNB testnet network.
+var OpBNBTestnetBootnodes = []string{
+	// geth
+	"enr:-KO4QKFOBDW--pF4pFwv3Al_jiLOITj_Y5mr1Ajyy2yxHpFtNcBfkZEkvWUxAKXQjWALZEFxYHooU88JClyzA00e8YeGAYtBOOZig2V0aMfGhE0ZYGqAgmlkgnY0gmlwhDREiqaJc2VjcDI1NmsxoQM8pC_6wwTr5N2Q-yXQ1KGKsgz9i9EPLk8Ata65pUyYG4RzbmFwwIN0Y3CCdl-DdWRwgnZf",
+	"enr:-KO4QFJc0KR09ye818GT2kyN9y6BAGjhz77sYimxn85jJf2hOrNqg4X0b0EsS-_ssdkzVpavqh6oMX7W5Y81xMRuEayGAYtBSiK9g2V0aMfGhE0ZYGqAgmlkgnY0gmlwhANzx96Jc2VjcDI1NmsxoQPwA1XHfWGd4umIt7j3Fc7hKq_35izIWT_9yiN_tX8lR4RzbmFwwIN0Y3CCdl-DdWRwgnZf",
 }
 
 // SepoliaBootnodes are the enode URLs of the P2P bootstrap nodes running on the


### PR DESCRIPTION
### Description

Add `opBNB` testnet and mainnet bootnodes in code.

### Rationale

Add `opBNB` testnet and mainnet bootnodes in code can facilitate the startup of new nodes.

### Example

The startup node will use the `opBNB` mainnet's bootnodes by default. If the `--networkid` is configured and it is testnet, the testnet bootnodes will be used. If `--bootnodes` is configured, the configured bootnodes will be used. The configured `--bootnodes` have the highest priority.

### Changes

Add `opBNB` testnet and mainnet bootnodes in code.
