### PR TITLE
chore: add reannounce metric for txpool

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -111,6 +111,8 @@ var (
 )
 
 var (
+	staledMeter = metrics.NewRegisteredMeter("txpool/staled/count", nil) // staled transactions
+
 	// Metrics for the pending pool
 	pendingDiscardMeter   = metrics.NewRegisteredMeter("txpool/pending/discard", nil)
 	pendingReplaceMeter   = metrics.NewRegisteredMeter("txpool/pending/replace", nil)
@@ -451,6 +453,7 @@ func (pool *TxPool) loop() {
 				return txs
 			}()
 			pool.mu.RUnlock()
+			staledMeter.Mark(int64(len(reannoTxs)))
 			if len(reannoTxs) > 0 {
 				pool.reannoTxFeed.Send(core.ReannoTxsEvent{reannoTxs})
 			}


### PR DESCRIPTION
### Description

add metric for staled transaction in txpool. It works only if the reannouncement function is enabled. The new metric is:
`txpool/staled/count`