### PR TITLE
feat: add TrieCommitInterval configuration, commit trie every TrieCommitInterval blocks.

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1424,7 +1424,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			chosen := current - bc.cacheConfig.TriesInMemory
 			flushInterval := time.Duration(atomic.LoadInt64(&bc.flushInterval))
 			// If we exceeded time allowance, flush an entire trie to disk
-			if bc.gcproc > flushInterval {
+			if bc.gcproc > flushInterval || chosen%240 == 0 {
 				// If the header is missing (canonical chain behind), we're reorging a low
 				// diff sidechain. Suspend committing until this operation is completed.
 				header := bc.GetHeaderByNumber(chosen)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -199,6 +199,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			TriesInMemory:       config.TriesInMemory,
 			SnapshotLimit:       config.SnapshotCache,
 			Preimages:           config.Preimages,
+			TrieCommitInterval:  config.TrieCommitInterval,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -84,6 +84,7 @@ var Defaults = Config{
 	TrieDirtyCache:          256,
 	TrieTimeout:             60 * time.Minute,
 	TriesInMemory:           128,
+	TrieCommitInterval:      0,
 	SnapshotCache:           102,
 	FilterLogCacheSize:      32,
 	Miner:                   miner.DefaultConfig,
@@ -168,6 +169,7 @@ type Config struct {
 	TrieDirtyCache          int
 	TrieTimeout             time.Duration
 	TriesInMemory           uint64 // How many tries keeps in memory
+	TrieCommitInterval      uint64 // Define a block height interval, commit trie every TrieCommitInterval block height.
 	SnapshotCache           int
 	Preimages               bool
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -3,6 +3,7 @@
 package ethconfig
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -18,50 +19,58 @@ import (
 // MarshalTOML marshals as TOML.
 func (c Config) MarshalTOML() (interface{}, error) {
 	type Config struct {
-		Genesis                 *core.Genesis `toml:",omitempty"`
-		NetworkId               uint64
-		SyncMode                downloader.SyncMode
-		EthDiscoveryURLs        []string
-		SnapDiscoveryURLs       []string
-		NoPruning               bool
-		NoPrefetch              bool
-		TxLookupLimit           uint64                 `toml:",omitempty"`
-		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
-		LightServ               int                    `toml:",omitempty"`
-		LightIngress            int                    `toml:",omitempty"`
-		LightEgress             int                    `toml:",omitempty"`
-		LightPeers              int                    `toml:",omitempty"`
-		LightNoPrune            bool                   `toml:",omitempty"`
-		LightNoSyncServe        bool                   `toml:",omitempty"`
-		SyncFromCheckpoint      bool                   `toml:",omitempty"`
-		UltraLightServers       []string               `toml:",omitempty"`
-		UltraLightFraction      int                    `toml:",omitempty"`
-		UltraLightOnlyAnnounce  bool                   `toml:",omitempty"`
-		SkipBcVersionCheck      bool                   `toml:"-"`
-		DatabaseHandles         int                    `toml:"-"`
-		DatabaseCache           int
-		DatabaseFreezer         string
-		TrieCleanCache          int
-		TrieCleanCacheJournal   string        `toml:",omitempty"`
-		TrieCleanCacheRejournal time.Duration `toml:",omitempty"`
-		TrieDirtyCache          int
-		TrieTimeout             time.Duration
-		TriesInMemory           uint64 `toml:",omitempty"`
-		SnapshotCache           int
-		Preimages               bool
-		FilterLogCacheSize      int
-		Miner                   miner.Config
-		Ethash                  ethash.Config
-		TxPool                  txpool.Config
-		GPO                     gasprice.Config
-		EnablePreimageRecording bool
-		DocRoot                 string `toml:"-"`
-		RPCGasCap               uint64
-		RPCEVMTimeout           time.Duration
-		RPCTxFeeCap             float64
-		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
-		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
-		OverrideShanghai        *uint64                        `toml:",omitempty"`
+		Genesis                    *core.Genesis `toml:",omitempty"`
+		NetworkId                  uint64
+		SyncMode                   downloader.SyncMode
+		EthDiscoveryURLs           []string
+		SnapDiscoveryURLs          []string
+		NoPruning                  bool
+		NoPrefetch                 bool
+		TxLookupLimit              uint64                 `toml:",omitempty"`
+		RequiredBlocks             map[uint64]common.Hash `toml:"-"`
+		LightServ                  int                    `toml:",omitempty"`
+		LightIngress               int                    `toml:",omitempty"`
+		LightEgress                int                    `toml:",omitempty"`
+		LightPeers                 int                    `toml:",omitempty"`
+		LightNoPrune               bool                   `toml:",omitempty"`
+		LightNoSyncServe           bool                   `toml:",omitempty"`
+		SyncFromCheckpoint         bool                   `toml:",omitempty"`
+		UltraLightServers          []string               `toml:",omitempty"`
+		UltraLightFraction         int                    `toml:",omitempty"`
+		UltraLightOnlyAnnounce     bool                   `toml:",omitempty"`
+		SkipBcVersionCheck         bool                   `toml:"-"`
+		DatabaseHandles            int                    `toml:"-"`
+		DatabaseCache              int
+		DatabaseFreezer            string
+		TrieCleanCache             int
+		TrieCleanCacheJournal      string        `toml:",omitempty"`
+		TrieCleanCacheRejournal    time.Duration `toml:",omitempty"`
+		TrieDirtyCache             int
+		TrieTimeout                time.Duration
+		TriesInMemory              uint64
+		TrieCommitInterval         uint64
+		SnapshotCache              int
+		Preimages                  bool
+		FilterLogCacheSize         int
+		Miner                      miner.Config
+		Ethash                     ethash.Config
+		TxPool                     txpool.Config
+		GPO                        gasprice.Config
+		EnablePreimageRecording    bool
+		DocRoot                    string `toml:"-"`
+		RPCGasCap                  uint64
+		RPCEVMTimeout              time.Duration
+		RPCTxFeeCap                float64
+		Checkpoint                 *params.TrustedCheckpoint      `toml:",omitempty"`
+		CheckpointOracle           *params.CheckpointOracleConfig `toml:",omitempty"`
+		OverrideShanghai           *uint64                        `toml:",omitempty"`
+		OverrideOptimismBedrock    *big.Int
+		OverrideOptimismRegolith   *uint64 `toml:",omitempty"`
+		OverrideOptimism           *bool
+		RollupSequencerHTTP        string
+		RollupHistoricalRPC        string
+		RollupHistoricalRPCTimeout time.Duration
+		RollupDisableTxPoolGossip  bool
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -93,6 +102,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.TrieDirtyCache = c.TrieDirtyCache
 	enc.TrieTimeout = c.TrieTimeout
 	enc.TriesInMemory = c.TriesInMemory
+	enc.TrieCommitInterval = c.TrieCommitInterval
 	enc.SnapshotCache = c.SnapshotCache
 	enc.Preimages = c.Preimages
 	enc.FilterLogCacheSize = c.FilterLogCacheSize
@@ -108,56 +118,71 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
 	enc.OverrideShanghai = c.OverrideShanghai
+	enc.OverrideOptimismBedrock = c.OverrideOptimismBedrock
+	enc.OverrideOptimismRegolith = c.OverrideOptimismRegolith
+	enc.OverrideOptimism = c.OverrideOptimism
+	enc.RollupSequencerHTTP = c.RollupSequencerHTTP
+	enc.RollupHistoricalRPC = c.RollupHistoricalRPC
+	enc.RollupHistoricalRPCTimeout = c.RollupHistoricalRPCTimeout
+	enc.RollupDisableTxPoolGossip = c.RollupDisableTxPoolGossip
 	return &enc, nil
 }
 
 // UnmarshalTOML unmarshals from TOML.
 func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	type Config struct {
-		Genesis                 *core.Genesis `toml:",omitempty"`
-		NetworkId               *uint64
-		SyncMode                *downloader.SyncMode
-		EthDiscoveryURLs        []string
-		SnapDiscoveryURLs       []string
-		NoPruning               *bool
-		NoPrefetch              *bool
-		TxLookupLimit           *uint64                `toml:",omitempty"`
-		RequiredBlocks          map[uint64]common.Hash `toml:"-"`
-		LightServ               *int                   `toml:",omitempty"`
-		LightIngress            *int                   `toml:",omitempty"`
-		LightEgress             *int                   `toml:",omitempty"`
-		LightPeers              *int                   `toml:",omitempty"`
-		LightNoPrune            *bool                  `toml:",omitempty"`
-		LightNoSyncServe        *bool                  `toml:",omitempty"`
-		SyncFromCheckpoint      *bool                  `toml:",omitempty"`
-		UltraLightServers       []string               `toml:",omitempty"`
-		UltraLightFraction      *int                   `toml:",omitempty"`
-		UltraLightOnlyAnnounce  *bool                  `toml:",omitempty"`
-		SkipBcVersionCheck      *bool                  `toml:"-"`
-		DatabaseHandles         *int                   `toml:"-"`
-		DatabaseCache           *int
-		DatabaseFreezer         *string
-		TrieCleanCache          *int
-		TrieCleanCacheJournal   *string        `toml:",omitempty"`
-		TrieCleanCacheRejournal *time.Duration `toml:",omitempty"`
-		TrieDirtyCache          *int
-		TrieTimeout             *time.Duration
-		TriesInMemory           *uint64 `toml:",omitempty"`
-		SnapshotCache           *int
-		Preimages               *bool
-		FilterLogCacheSize      *int
-		Miner                   *miner.Config
-		Ethash                  *ethash.Config
-		TxPool                  *txpool.Config
-		GPO                     *gasprice.Config
-		EnablePreimageRecording *bool
-		DocRoot                 *string `toml:"-"`
-		RPCGasCap               *uint64
-		RPCEVMTimeout           *time.Duration
-		RPCTxFeeCap             *float64
-		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
-		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
-		OverrideShanghai        *uint64                        `toml:",omitempty"`
+		Genesis                    *core.Genesis `toml:",omitempty"`
+		NetworkId                  *uint64
+		SyncMode                   *downloader.SyncMode
+		EthDiscoveryURLs           []string
+		SnapDiscoveryURLs          []string
+		NoPruning                  *bool
+		NoPrefetch                 *bool
+		TxLookupLimit              *uint64                `toml:",omitempty"`
+		RequiredBlocks             map[uint64]common.Hash `toml:"-"`
+		LightServ                  *int                   `toml:",omitempty"`
+		LightIngress               *int                   `toml:",omitempty"`
+		LightEgress                *int                   `toml:",omitempty"`
+		LightPeers                 *int                   `toml:",omitempty"`
+		LightNoPrune               *bool                  `toml:",omitempty"`
+		LightNoSyncServe           *bool                  `toml:",omitempty"`
+		SyncFromCheckpoint         *bool                  `toml:",omitempty"`
+		UltraLightServers          []string               `toml:",omitempty"`
+		UltraLightFraction         *int                   `toml:",omitempty"`
+		UltraLightOnlyAnnounce     *bool                  `toml:",omitempty"`
+		SkipBcVersionCheck         *bool                  `toml:"-"`
+		DatabaseHandles            *int                   `toml:"-"`
+		DatabaseCache              *int
+		DatabaseFreezer            *string
+		TrieCleanCache             *int
+		TrieCleanCacheJournal      *string        `toml:",omitempty"`
+		TrieCleanCacheRejournal    *time.Duration `toml:",omitempty"`
+		TrieDirtyCache             *int
+		TrieTimeout                *time.Duration
+		TriesInMemory              *uint64
+		TrieCommitInterval         *uint64
+		SnapshotCache              *int
+		Preimages                  *bool
+		FilterLogCacheSize         *int
+		Miner                      *miner.Config
+		Ethash                     *ethash.Config
+		TxPool                     *txpool.Config
+		GPO                        *gasprice.Config
+		EnablePreimageRecording    *bool
+		DocRoot                    *string `toml:"-"`
+		RPCGasCap                  *uint64
+		RPCEVMTimeout              *time.Duration
+		RPCTxFeeCap                *float64
+		Checkpoint                 *params.TrustedCheckpoint      `toml:",omitempty"`
+		CheckpointOracle           *params.CheckpointOracleConfig `toml:",omitempty"`
+		OverrideShanghai           *uint64                        `toml:",omitempty"`
+		OverrideOptimismBedrock    *big.Int
+		OverrideOptimismRegolith   *uint64 `toml:",omitempty"`
+		OverrideOptimism           *bool
+		RollupSequencerHTTP        *string
+		RollupHistoricalRPC        *string
+		RollupHistoricalRPCTimeout *time.Duration
+		RollupDisableTxPoolGossip  *bool
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -250,6 +275,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	if dec.TriesInMemory != nil {
 		c.TriesInMemory = *dec.TriesInMemory
 	}
+	if dec.TrieCommitInterval != nil {
+		c.TrieCommitInterval = *dec.TrieCommitInterval
+	}
 	if dec.SnapshotCache != nil {
 		c.SnapshotCache = *dec.SnapshotCache
 	}
@@ -294,6 +322,27 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.OverrideShanghai != nil {
 		c.OverrideShanghai = dec.OverrideShanghai
+	}
+	if dec.OverrideOptimismBedrock != nil {
+		c.OverrideOptimismBedrock = dec.OverrideOptimismBedrock
+	}
+	if dec.OverrideOptimismRegolith != nil {
+		c.OverrideOptimismRegolith = dec.OverrideOptimismRegolith
+	}
+	if dec.OverrideOptimism != nil {
+		c.OverrideOptimism = dec.OverrideOptimism
+	}
+	if dec.RollupSequencerHTTP != nil {
+		c.RollupSequencerHTTP = *dec.RollupSequencerHTTP
+	}
+	if dec.RollupHistoricalRPC != nil {
+		c.RollupHistoricalRPC = *dec.RollupHistoricalRPC
+	}
+	if dec.RollupHistoricalRPCTimeout != nil {
+		c.RollupHistoricalRPCTimeout = *dec.RollupHistoricalRPCTimeout
+	}
+	if dec.RollupDisableTxPoolGossip != nil {
+		c.RollupDisableTxPoolGossip = *dec.RollupDisableTxPoolGossip
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Currently, all of our nodes can only be set to archive mode for gcMode. As the amount of data gradually increases, each of our nodes needs to be able to configure to full mode. This mode will delete Trie data that is lower than the latest block height minus TriesInMemory blocks, instead of committing and storing it in the database. This way, our nodes will occupy less disk space and have better performance. However, our official bridge and proposer components both need to use Trie data from about 1 hour ago. After enabling full mode, both the official bridge and proposer components will not function properly.
We need to enable full mode, and at the same time, we need to solve the problem of the official bridge and proposer using Trie data.

### Rationale

It should be noted that the full mode does not discard all Trie data. It has a gcproc statistic that tracks the cumulative time spent processing blocks. When gcproc is greater than flushInterval (default is 1 hour), the full mode will commit and store the complete Trie data for the current block height minus TriesInMemory  in the database. On the other hand, the submission frequency of our Mainnet and Testnet proposers is fixed and controlled by the configuration l2OutputOracleSubmissionInterval. We can use this configuration to calculate which block heights the official bridge and proposers need to use. Therefore, we add a TrieCommitInterval configuration in geth, whose value is equal to the value of l2OutputOracleSubmissionInterval for the corresponding network. In our code, we add a judgment condition that when the target block height (i.e. the latest block height minus TriesInMemory) divided by TrieCommitInterval results in a remainder of 0, it means that the target block height is the block height where we need to save the Trie data. We then commit the Trie data and store it in the database.


### Example
add TrieCommitInterval config in config.toml
```toml
[Eth]
TrieCommitInterval = 240
```
then add `gcMode=full` to geth param.
All Trie data for block heights that are multiples of 240 will be available.

### Changes

Notable changes:
* Add TrieCommitInterval configuration option
* Add an additional condition after bc.gcproc > flushInterval, where chosen block height is divisible by TrieCommitInterval, commit triedb.
