### PR TITLE
fix: fix base buffer concurrent read/write race

### DIFF
--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -122,6 +122,7 @@ func newNodeBufferList(
 // node retrieves the trie node with given node info.
 func (nf *nodebufferlist) node(owner common.Hash, path []byte, hash common.Hash) (node *trienode.Node, err error) {
 	nf.mux.RLock()
+	defer nf.mux.RUnlock()
 	find := func(nc *multiDifflayer) bool {
 		subset, ok := nc.nodes[owner]
 		if !ok {
@@ -141,14 +142,11 @@ func (nf *nodebufferlist) node(owner common.Hash, path []byte, hash common.Hash)
 	}
 	nf.traverse(find)
 	if err != nil {
-		nf.mux.RUnlock()
 		return nil, err
 	}
 	if node != nil {
-		nf.mux.RUnlock()
 		return node, nil
 	}
-	nf.mux.RUnlock()
 
 	nf.baseMux.RLock()
 	node, err = nf.base.node(owner, path, hash)
@@ -602,10 +600,13 @@ func (w *proposedBlockReader) Node(owner common.Hash, path []byte, hash common.H
 		current = current.next
 	}
 
+	w.nf.baseMux.RLock()
 	node, err := w.nf.base.node(owner, path, hash)
 	if err != nil {
+		w.nf.baseMux.RUnlock()
 		return nil, err
 	}
+	w.nf.baseMux.RUnlock()
 	if node != nil {
 		return node.Blob, nil
 	}

--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -602,11 +602,10 @@ func (w *proposedBlockReader) Node(owner common.Hash, path []byte, hash common.H
 
 	w.nf.baseMux.RLock()
 	node, err := w.nf.base.node(owner, path, hash)
+	w.nf.baseMux.RUnlock()
 	if err != nil {
-		w.nf.baseMux.RUnlock()
 		return nil, err
 	}
-	w.nf.baseMux.RUnlock()
 	if node != nil {
 		return node.Blob, nil
 	}


### PR DESCRIPTION
### Description

Fix base buffer concurrent read/write race.

### Rationale

Fix the map in the base from being accessed and modified concurrently.

### Example

N/A.

### Changes

Notable changes:
* pathdb bufferlist.
