### PR TITLE
core/trie: persist TrieJournal to journal file instead of kv database

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -198,7 +198,7 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		defer chaindb.Close()
 
-		triedb := utils.MakeTrieDatabase(ctx, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
+		triedb := utils.MakeTrieDatabase(ctx, stack, chaindb, ctx.Bool(utils.CachePreimagesFlag.Name), false, genesis.IsVerkle())
 		defer triedb.Close()
 
 		_, hash, err := core.SetupGenesisBlockWithOverride(chaindb, triedb, genesis, &overrides)
@@ -463,7 +463,7 @@ func dump(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	triedb := utils.MakeTrieDatabase(ctx, db, true, true, false) // always enable preimage lookup
+	triedb := utils.MakeTrieDatabase(ctx, stack, db, true, true, false) // always enable preimage lookup
 	defer triedb.Close()
 
 	state, err := state.New(root, state.NewDatabaseWithNodeDB(db, triedb), nil)

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -398,7 +398,7 @@ func inspectTrie(ctx *cli.Context) error {
 		var config *trie.Config
 		if dbScheme == rawdb.PathScheme {
 			config = &trie.Config{
-				PathDB: pathdb.ReadOnly,
+				PathDB: utils.PathDBConfigAddJournalFilePath(stack, pathdb.ReadOnly),
 			}
 		} else if dbScheme == rawdb.HashScheme {
 			config = trie.HashDefaults
@@ -774,8 +774,7 @@ func dbDumpTrie(ctx *cli.Context) error {
 
 	db := utils.MakeChainDatabase(ctx, stack, true)
 	defer db.Close()
-
-	triedb := utils.MakeTrieDatabase(ctx, db, false, true, false)
+	triedb := utils.MakeTrieDatabase(ctx, stack, db, false, true, false)
 	defer triedb.Close()
 
 	var (

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -100,6 +100,7 @@ var (
 		utils.PathDBNodeBufferTypeFlag,
 		utils.EnableProofKeeperFlag,
 		utils.KeepProofBlockSpanFlag,
+		utils.JournalFileFlag,
 		utils.LightServeFlag,    // deprecated
 		utils.LightIngressFlag,  // deprecated
 		utils.LightEgressFlag,   // deprecated

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	cli "github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -244,7 +244,7 @@ func verifyState(ctx *cli.Context) error {
 		log.Error("Failed to load head block")
 		return errors.New("no head block")
 	}
-	triedb := utils.MakeTrieDatabase(ctx, chaindb, false, true, false)
+	triedb := utils.MakeTrieDatabase(ctx, stack, chaindb, false, true, false)
 	defer triedb.Close()
 
 	snapConfig := snapshot.Config{
@@ -299,7 +299,7 @@ func traverseState(ctx *cli.Context) error {
 	chaindb := utils.MakeChainDatabase(ctx, stack, true)
 	defer chaindb.Close()
 
-	triedb := utils.MakeTrieDatabase(ctx, chaindb, false, true, false)
+	triedb := utils.MakeTrieDatabase(ctx, stack, chaindb, false, true, false)
 	defer triedb.Close()
 
 	headBlock := rawdb.ReadHeadBlock(chaindb)
@@ -408,7 +408,7 @@ func traverseRawState(ctx *cli.Context) error {
 	chaindb := utils.MakeChainDatabase(ctx, stack, true)
 	defer chaindb.Close()
 
-	triedb := utils.MakeTrieDatabase(ctx, chaindb, false, true, false)
+	triedb := utils.MakeTrieDatabase(ctx, stack, chaindb, false, true, false)
 	defer triedb.Close()
 
 	headBlock := rawdb.ReadHeadBlock(chaindb)
@@ -572,7 +572,8 @@ func dumpState(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	triedb := utils.MakeTrieDatabase(ctx, db, false, true, false)
+	defer db.Close()
+	triedb := utils.MakeTrieDatabase(ctx, stack, db, false, true, false)
 	defer triedb.Close()
 
 	snapConfig := snapshot.Config{
@@ -654,7 +655,7 @@ func snapshotExportPreimages(ctx *cli.Context) error {
 	chaindb := utils.MakeChainDatabase(ctx, stack, true)
 	defer chaindb.Close()
 
-	triedb := utils.MakeTrieDatabase(ctx, chaindb, false, true, false)
+	triedb := utils.MakeTrieDatabase(ctx, stack, chaindb, false, true, false)
 	defer triedb.Close()
 
 	var root common.Hash

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -34,7 +34,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/opcodeCompiler/compiler"
 	pcsclite "github.com/gballet/go-libpcsclite"
 	gopsutil "github.com/shirou/gopsutil/mem"
 	"github.com/urfave/cli/v2"

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -340,6 +340,12 @@ var (
 		Value:    params.FullImmutabilityThreshold,
 		Category: flags.StateCategory,
 	}
+	JournalFileFlag = &cli.BoolFlag{
+		Name:     "journalfile",
+		Usage:    "Enable using journal file to store the TrieJournal instead of KVDB in pbss (default = false)",
+		Value:    false,
+		Category: flags.StateCategory,
+	}
 	StateHistoryFlag = &cli.Uint64Flag{
 		Name:     "history.state",
 		Usage:    "Number of recent blocks to retain state history for (default = 90,000 blocks, 0 = entire chain)",
@@ -1878,6 +1884,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(KeepProofBlockSpanFlag.Name) {
 		cfg.KeepProofBlockSpan = ctx.Uint64(KeepProofBlockSpanFlag.Name)
 	}
+	if ctx.IsSet(JournalFileFlag.Name) {
+		cfg.JournalFileEnabled = true
+	}
+
 	if ctx.String(GCModeFlag.Name) == "archive" && cfg.TransactionHistory != 0 {
 		cfg.TransactionHistory = 0
 		log.Warn("Disabled transaction unindexing for archive node")

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -162,6 +162,7 @@ type CacheConfig struct {
 	KeepProofBlockSpan   uint64                // Block span of keep proof
 	SnapshotNoBuild      bool                  // Whether the background generation is allowed
 	SnapshotWait         bool                  // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
+	JournalFilePath      string
 
 	TrieCommitInterval uint64 // Define a block height interval, commit trie every TrieCommitInterval block height.
 }
@@ -185,6 +186,7 @@ func (c *CacheConfig) triedbConfig(keepFunc pathdb.NotifyKeepFunc) *trie.Config 
 			DirtyCacheSize:       c.TrieDirtyLimit * 1024 * 1024,
 			ProposeBlockInterval: c.ProposeBlockInterval,
 			NotifyKeep:           keepFunc,
+			JournalFilePath:      c.JournalFilePath,
 		}
 	}
 	return config

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -163,6 +163,7 @@ type CacheConfig struct {
 	SnapshotNoBuild      bool                  // Whether the background generation is allowed
 	SnapshotWait         bool                  // Wait for snapshot construction on startup. TODO(karalabe): This is a dirty hack for testing, nuke it
 	JournalFilePath      string
+	JournalFile          bool
 
 	TrieCommitInterval uint64 // Define a block height interval, commit trie every TrieCommitInterval block height.
 }
@@ -187,6 +188,7 @@ func (c *CacheConfig) triedbConfig(keepFunc pathdb.NotifyKeepFunc) *trie.Config 
 			ProposeBlockInterval: c.ProposeBlockInterval,
 			NotifyKeep:           keepFunc,
 			JournalFilePath:      c.JournalFilePath,
+			JournalFile:          c.JournalFile,
 		}
 	}
 	return config

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -207,10 +207,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		journalFilePath string
 		path            string
 	)
-	if config.JournalFileEnabled {
-		path = ChainData
-		journalFilePath = stack.ResolvePath(path) + "/" + JournalFileName
-	}
+	path = ChainData
+	journalFilePath = stack.ResolvePath(path) + "/" + JournalFileName
 	var (
 		vmConfig = vm.Config{
 			EnablePreimageRecording:   config.EnablePreimageRecording,
@@ -233,6 +231,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnableProofKeeper:    config.EnableProofKeeper,
 			KeepProofBlockSpan:   config.KeepProofBlockSpan,
 			JournalFilePath:      journalFilePath,
+			JournalFile:          config.JournalFileEnabled,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -61,6 +61,12 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const (
+	ChainDBNamespace = "eth/db/chaindata/"
+	JournalFileName  = "trie.journal"
+	ChainData        = "chaindata"
+)
+
 // Config contains the configuration options of the ETH protocol.
 // Deprecated: use ethconfig.Config instead.
 type Config = ethconfig.Config
@@ -136,7 +142,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	log.Info("Allocated trie memory caches", "clean", common.StorageSize(config.TrieCleanCache)*1024*1024, "dirty", common.StorageSize(config.TrieDirtyCache)*1024*1024)
 
 	// Assemble the Ethereum object
-	chainDb, err := stack.OpenDatabaseWithFreezer("chaindata", config.DatabaseCache, config.DatabaseHandles, config.DatabaseFreezer, "eth/db/chaindata/", false)
+	chainDb, err := stack.OpenDatabaseWithFreezer(ChainData, config.DatabaseCache, config.DatabaseHandles,
+		config.DatabaseFreezer, ChainDBNamespace, false)
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +204,14 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 	}
 	var (
+		journalFilePath string
+		path            string
+	)
+	if config.JournalFileEnabled {
+		path = ChainData
+		journalFilePath = stack.ResolvePath(path) + "/" + JournalFileName
+	}
+	var (
 		vmConfig = vm.Config{
 			EnablePreimageRecording:   config.EnablePreimageRecording,
 			EnableOpcodeOptimizations: config.EnableOpcodeOptimizing,
@@ -217,6 +232,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			ProposeBlockInterval: config.ProposeBlockInterval,
 			EnableProofKeeper:    config.EnableProofKeeper,
 			KeepProofBlockSpan:   config.KeepProofBlockSpan,
+			JournalFilePath:      journalFilePath,
 		}
 	)
 	// Override the chain config with provided settings.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -203,12 +203,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			rawdb.WriteDatabaseVersion(chainDb, core.BlockChainVersion)
 		}
 	}
-	var (
-		journalFilePath string
-		path            string
-	)
-	path = ChainData
-	journalFilePath = stack.ResolvePath(path) + "/" + JournalFileName
+
+	journalFilePath := fmt.Sprintf("%s/%s", stack.ResolvePath(ChainData), JournalFileName)
 	var (
 		vmConfig = vm.Config{
 			EnablePreimageRecording:   config.EnablePreimageRecording,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -50,26 +50,26 @@ var FullNodeGPO = gasprice.Config{
 
 // Defaults contains default settings for use on the Ethereum main net.
 var Defaults = Config{
-	SyncMode:           downloader.SnapSync,
-	NetworkId:          0,
-	TxLookupLimit:      2350000,
-	TransactionHistory: 2350000,
-	StateHistory:       params.FullImmutabilityThreshold,
-	LightPeers:         100,
-	DatabaseCache:      512,
-	TrieCleanCache:     154,
-	TrieDirtyCache:     256,
-	TrieTimeout:        60 * time.Minute,
-	TrieCommitInterval: 0,
-	SnapshotCache:      102,
-	FilterLogCacheSize: 32,
-	Miner:              miner.DefaultConfig,
-	TxPool:             legacypool.DefaultConfig,
-	BlobPool:           blobpool.DefaultConfig,
-	RPCGasCap:          50000000,
-	RPCEVMTimeout:      5 * time.Second,
-	GPO:                FullNodeGPO,
-	RPCTxFeeCap:        1, // 1 ether
+	SyncMode:               downloader.SnapSync,
+	NetworkId:              0,
+	TxLookupLimit:          2350000,
+	TransactionHistory:     2350000,
+	StateHistory:           params.FullImmutabilityThreshold,
+	LightPeers:             100,
+	DatabaseCache:          512,
+	TrieCleanCache:         154,
+	TrieDirtyCache:         256,
+	TrieTimeout:            60 * time.Minute,
+	TrieCommitInterval:     0,
+	SnapshotCache:          102,
+	FilterLogCacheSize:     32,
+	Miner:                  miner.DefaultConfig,
+	TxPool:                 legacypool.DefaultConfig,
+	BlobPool:               blobpool.DefaultConfig,
+	RPCGasCap:              50000000,
+	RPCEVMTimeout:          5 * time.Second,
+	GPO:                    FullNodeGPO,
+	RPCTxFeeCap:            1, // 1 ether
 	EnableOpcodeOptimizing: false,
 }
 
@@ -134,7 +134,7 @@ type Config struct {
 	ProposeBlockInterval uint64                `toml:",omitempty"` // Keep the same with op-proposer propose block interval
 	EnableProofKeeper    bool                  `toml:",omitempty"` // Whether to enable proof keeper
 	KeepProofBlockSpan   uint64                `toml:",omitempty"` // Span block of keep proof
-	JournalFileEnabled   bool                  // Whether the TrieJournal is stored using journal file
+	JournalFileEnabled   bool                  `toml:",omitempty"` // Whether the TrieJournal is stored using journal file
 
 	// RequiredBlocks is a set of block number -> hash mappings which must be in the
 	// canonical chain of all remote peers. Setting the option makes geth verify the

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -134,6 +134,7 @@ type Config struct {
 	ProposeBlockInterval uint64                `toml:",omitempty"` // Keep the same with op-proposer propose block interval
 	EnableProofKeeper    bool                  `toml:",omitempty"` // Whether to enable proof keeper
 	KeepProofBlockSpan   uint64                `toml:",omitempty"` // Span block of keep proof
+	JournalFileEnabled   bool                  // Whether the TrieJournal is stored using journal file
 
 	// RequiredBlocks is a set of block number -> hash mappings which must be in the
 	// canonical chain of all remote peers. Setting the option makes geth verify the

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -31,6 +31,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		StateScheme                             string                 `toml:",omitempty"`
 		PathNodeBuffer                          pathdb.NodeBufferType  `toml:",omitempty"`
 		ProposeBlockInterval                    uint64                 `toml:",omitempty"`
+		JournalFileEnabled                      bool                   `toml:",omitempty"`
 		RequiredBlocks                          map[uint64]common.Hash `toml:"-"`
 		LightServ                               int                    `toml:",omitempty"`
 		LightIngress                            int                    `toml:",omitempty"`
@@ -87,6 +88,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.StateScheme = c.StateScheme
 	enc.PathNodeBuffer = c.PathNodeBuffer
 	enc.ProposeBlockInterval = c.ProposeBlockInterval
+	enc.JournalFileEnabled = c.JournalFileEnabled
 	enc.RequiredBlocks = c.RequiredBlocks
 	enc.LightServ = c.LightServ
 	enc.LightIngress = c.LightIngress
@@ -147,6 +149,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		StateScheme                             *string                `toml:",omitempty"`
 		PathNodeBuffer                          *pathdb.NodeBufferType `toml:",omitempty"`
 		ProposeBlockInterval                    *uint64                `toml:",omitempty"`
+		JournalFileEnabled                      *bool                  `toml:",omitempty"`
 		RequiredBlocks                          map[uint64]common.Hash `toml:"-"`
 		LightServ                               *int                   `toml:",omitempty"`
 		LightIngress                            *int                   `toml:",omitempty"`
@@ -231,6 +234,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.ProposeBlockInterval != nil {
 		c.ProposeBlockInterval = *dec.ProposeBlockInterval
+	}
+	if dec.JournalFileEnabled != nil {
+		c.JournalFileEnabled = *dec.JournalFileEnabled
 	}
 	if dec.RequiredBlocks != nil {
 		c.RequiredBlocks = dec.RequiredBlocks

--- a/node/node.go
+++ b/node/node.go
@@ -73,8 +73,6 @@ const (
 	closedState
 )
 
-const StateDBNamespace = "eth/db/statedata/"
-
 // New creates a new P2P node, ready for protocol registration.
 func New(conf *Config) (*Node, error) {
 	// Copy config and resolve the datadir so future changes to the current

--- a/node/node.go
+++ b/node/node.go
@@ -73,6 +73,8 @@ const (
 	closedState
 )
 
+const StateDBNamespace = "eth/db/statedata/"
+
 // New creates a new P2P node, ready for protocol registration.
 func New(conf *Config) (*Node, error) {
 	// Copy config and resolve the datadir so future changes to the current

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -63,6 +63,13 @@ const (
 	DefaultBatchRedundancyRate = 1.1
 )
 
+type JournalType int
+
+const (
+	JournalKVType JournalType = iota
+	JournalFileType
+)
+
 // layer is the interface implemented by all state layers which includes some
 // public methods and some additional methods for internal usage.
 type layer interface {
@@ -90,7 +97,7 @@ type layer interface {
 	// journal commits an entire diff hierarchy to disk into a single journal entry.
 	// This is meant to be used during shutdown to persist the layer without
 	// flattening everything down (bad for reorgs).
-	journal(w io.Writer, journalFile bool) error
+	journal(w io.Writer, journalType JournalType) error
 }
 
 // Config contains the settings for database.
@@ -103,6 +110,7 @@ type Config struct {
 	ProposeBlockInterval uint64         // Propose block to L1 block interval.
 	NotifyKeep           NotifyKeepFunc // NotifyKeep is used to keep the proof which maybe queried by op-proposer.
 	JournalFilePath      string
+	JournalFile     bool
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -512,23 +520,40 @@ func (db *Database) modifyAllowed() error {
 	return nil
 }
 
-func (db *Database) IsEnableJournalFile() bool {
-	return len(db.config.JournalFilePath) != 0
+// DetermineJournalTypeForWriter is used when persisting the journal. It determines JournalType based on the config passed in by the Config.
+func (db *Database) DetermineJournalTypeForWriter() JournalType {
+	if db.config.JournalFile {
+		return JournalFileType
+	} else {
+		return JournalKVType
+	}
+}
+
+// DetermineJournalTypeForReader is used when loading the journal. It loads based on whether JournalKV or JournalFile currently exists.
+func (db *Database) DetermineJournalTypeForReader() JournalType {
+	if journal := rawdb.ReadTrieJournal(db.diskdb); len(journal) != 0 {
+		return JournalKVType
+	}
+
+	if fileInfo, stateErr := os.Stat(db.config.JournalFilePath); stateErr == nil && !fileInfo.IsDir() {
+		return JournalFileType
+	}
+
+	return JournalKVType
 }
 
 func (db *Database) DeleteTrieJournal(writer ethdb.KeyValueWriter) error {
+	// To prevent any remnants of old journals after converting from JournalKV to JournalFile or vice versa, all deletions must be completed.
+	rawdb.DeleteTrieJournal(writer)
+
+	// delete from journal file, may not exist
 	filePath := db.config.JournalFilePath
-	if len(filePath) == 0 {
-		rawdb.DeleteTrieJournal(writer)
-	} else {
-		_, err := os.Stat(filePath)
-		if os.IsNotExist(err) {
-			return err
-		}
-		errRemove := os.Remove(filePath)
-		if errRemove != nil {
-			log.Crit("Failed to remove tries journal", "journal path", filePath, "err", err)
-		}
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil
+	}
+	errRemove := os.Remove(filePath)
+	if errRemove != nil {
+		log.Crit("Failed to remove tries journal", "journal path", filePath, "err", errRemove)
 	}
 	return nil
 }

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -109,8 +109,8 @@ type Config struct {
 	ReadOnly             bool           // Flag whether the database is opened in read only mode.
 	ProposeBlockInterval uint64         // Propose block to L1 block interval.
 	NotifyKeep           NotifyKeepFunc // NotifyKeep is used to keep the proof which maybe queried by op-proposer.
-	JournalFilePath      string
-	JournalFile     bool
+	JournalFilePath      string         // The journal file path
+	JournalFile          bool           // Whether to use journal file mode
 }
 
 // sanitize checks the provided user configurations and changes anything that's
@@ -520,7 +520,8 @@ func (db *Database) modifyAllowed() error {
 	return nil
 }
 
-// DetermineJournalTypeForWriter is used when persisting the journal. It determines JournalType based on the config passed in by the Config.
+// DetermineJournalTypeForWriter is used when persisting the journal.
+// It determines JournalType based on the config passed in by the Config.
 func (db *Database) DetermineJournalTypeForWriter() JournalType {
 	if db.config.JournalFile {
 		return JournalFileType
@@ -529,7 +530,8 @@ func (db *Database) DetermineJournalTypeForWriter() JournalType {
 	}
 }
 
-// DetermineJournalTypeForReader is used when loading the journal. It loads based on whether JournalKV or JournalFile currently exists.
+// DetermineJournalTypeForReader is used when loading the journal.
+// It loads based on whether JournalKV or JournalFile currently exists.
 func (db *Database) DetermineJournalTypeForReader() JournalType {
 	if journal := rawdb.ReadTrieJournal(db.diskdb); len(journal) != 0 {
 		return JournalKVType
@@ -542,8 +544,10 @@ func (db *Database) DetermineJournalTypeForReader() JournalType {
 	return JournalKVType
 }
 
+// DeleteTrieJournal deletes trie journal data.
 func (db *Database) DeleteTrieJournal(writer ethdb.KeyValueWriter) error {
-	// To prevent any remnants of old journals after converting from JournalKV to JournalFile or vice versa, all deletions must be completed.
+	// To prevent any remnants of old journals after converting from JournalKV to JournalFile
+	// or vice versa, all deletions must be completed.
 	rawdb.DeleteTrieJournal(writer)
 
 	// delete from journal file, may not exist

--- a/trie/triedb/pathdb/database.go
+++ b/trie/triedb/pathdb/database.go
@@ -90,7 +90,7 @@ type layer interface {
 	// journal commits an entire diff hierarchy to disk into a single journal entry.
 	// This is meant to be used during shutdown to persist the layer without
 	// flattening everything down (bad for reorgs).
-	journal(w io.Writer) error
+	journal(w io.Writer, journalFile bool) error
 }
 
 // Config contains the settings for database.
@@ -510,6 +510,10 @@ func (db *Database) modifyAllowed() error {
 		return errDatabaseWaitSync
 	}
 	return nil
+}
+
+func (db *Database) IsEnableJournalFile() bool {
+	return len(db.config.JournalFilePath) != 0
 }
 
 func (db *Database) DeleteTrieJournal(writer ethdb.KeyValueWriter) error {

--- a/trie/triedb/pathdb/difflayer_test.go
+++ b/trie/triedb/pathdb/difflayer_test.go
@@ -165,6 +165,6 @@ func BenchmarkJournal(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		layer.journal(new(bytes.Buffer))
+		layer.journal(new(bytes.Buffer), false)
 	}
 }

--- a/trie/triedb/pathdb/difflayer_test.go
+++ b/trie/triedb/pathdb/difflayer_test.go
@@ -165,6 +165,6 @@ func BenchmarkJournal(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		layer.journal(new(bytes.Buffer), false)
+		layer.journal(new(bytes.Buffer), JournalKVType)
 	}
 }

--- a/trie/triedb/pathdb/journal.go
+++ b/trie/triedb/pathdb/journal.go
@@ -151,8 +151,9 @@ func (kr *JournalKVReader) Read(p []byte) (n int, err error) {
 func (kr *JournalKVReader) Close() {
 }
 
-func newJournalWriter(file string, db ethdb.Database) JournalWriter {
-	if len(file) == 0 {
+func newJournalWriter(file string, db ethdb.Database, journalType JournalType) JournalWriter {
+	log.Info("New journal writer", "path", file, "journalType", journalType)
+	if journalType == JournalKVType {
 		return &JournalKVWriter{
 			diskdb: db,
 		}
@@ -167,8 +168,9 @@ func newJournalWriter(file string, db ethdb.Database) JournalWriter {
 	}
 }
 
-func newJournalReader(file string, db ethdb.Database) (JournalReader, error) {
-	if len(file) == 0 {
+func newJournalReader(file string, db ethdb.Database, journalType JournalType) (JournalReader, error) {
+	log.Info("New journal reader", "path", file, "journalType", journalType)
+	if journalType == JournalKVType {
 		journal := rawdb.ReadTrieJournal(db)
 		if len(journal) == 0 {
 			return nil, errMissJournal
@@ -193,7 +195,7 @@ func newJournalReader(file string, db ethdb.Database) (JournalReader, error) {
 // loadJournal tries to parse the layer journal from the disk.
 func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
 	start := time.Now()
-	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb)
+	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb, db.DetermineJournalTypeForReader())
 
 	if err != nil {
 		return nil, err
@@ -270,7 +272,7 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 		journalBuf         *rlp.Stream
 		journalEncodedBuff []byte
 	)
-	if db.IsEnableJournalFile() {
+	if db.DetermineJournalTypeForReader() == JournalFileType {
 		if err := r.Decode(&journalEncodedBuff); err != nil {
 			return nil, fmt.Errorf("load disk journal: %v", err)
 		}
@@ -311,7 +313,7 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 		nodes[entry.Owner] = subset
 	}
 
-	if db.IsEnableJournalFile() {
+	if db.DetermineJournalTypeForReader() == JournalFileType {
 		var shaSum [32]byte
 		if err := r.Decode(&shaSum); err != nil {
 			return nil, fmt.Errorf("load shasum: %v", err)
@@ -339,7 +341,7 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		journalBuf         *rlp.Stream
 		journalEncodedBuff []byte
 	)
-	if db.IsEnableJournalFile() {
+	if db.DetermineJournalTypeForReader() == JournalFileType {
 		if err := r.Decode(&journalEncodedBuff); err != nil {
 			// The first read may fail with EOF, marking the end of the journal
 			if err == io.EOF {
@@ -412,7 +414,7 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		storages[entry.Account] = set
 	}
 
-	if db.IsEnableJournalFile() {
+	if db.DetermineJournalTypeForReader() == JournalFileType {
 		var shaSum [32]byte
 		if err := r.Decode(&shaSum); err != nil {
 			return nil, fmt.Errorf("load shasum: %v", err)
@@ -431,7 +433,7 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 
 // journal implements the layer interface, marshaling the un-flushed trie nodes
 // along with layer metadata into provided byte buffer.
-func (dl *diskLayer) journal(w io.Writer, journalFile bool) error {
+func (dl *diskLayer) journal(w io.Writer, journalType JournalType) error {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
@@ -465,7 +467,7 @@ func (dl *diskLayer) journal(w io.Writer, journalFile bool) error {
 	}
 
 	// Store the journal buf into w and calculate checksum
-	if journalFile {
+	if journalType == JournalFileType {
 		shasum := sha256.Sum256(journalBuf.Bytes())
 		if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
 			return err
@@ -485,12 +487,12 @@ func (dl *diskLayer) journal(w io.Writer, journalFile bool) error {
 
 // journal implements the layer interface, writing the memory layer contents
 // into a buffer to be stored in the database as the layer journal.
-func (dl *diffLayer) journal(w io.Writer, journalFile bool) error {
+func (dl *diffLayer) journal(w io.Writer, journalType JournalType) error {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
 	// journal the parent first
-	if err := dl.parent.journal(w, journalFile); err != nil {
+	if err := dl.parent.journal(w, journalType); err != nil {
 		return err
 	}
 	// Create a buffer to store encoded data
@@ -540,7 +542,7 @@ func (dl *diffLayer) journal(w io.Writer, journalFile bool) error {
 	}
 
 	// Store the journal buf into w and calculate checksum
-	if journalFile {
+	if journalType == JournalFileType {
 		shasum := sha256.Sum256(journalBuf.Bytes())
 		if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
 			return err
@@ -588,7 +590,7 @@ func (db *Database) Journal(root common.Hash) error {
 	}
 	// Firstly write out the metadata of journal
 	db.DeleteTrieJournal(db.diskdb)
-	journal := newJournalWriter(db.config.JournalFilePath, db.diskdb)
+	journal := newJournalWriter(db.config.JournalFilePath, db.diskdb, db.DetermineJournalTypeForWriter())
 	defer journal.Close()
 
 	if err := rlp.Encode(journal, journalVersion); err != nil {
@@ -605,7 +607,7 @@ func (db *Database) Journal(root common.Hash) error {
 		return err
 	}
 	// Finally write out the journal of each layer in reverse order.
-	if err := l.journal(journal, db.IsEnableJournalFile()); err != nil {
+	if err := l.journal(journal, db.DetermineJournalTypeForWriter()); err != nil {
 		return err
 	}
 	// Store the journal into the database and return

--- a/trie/triedb/pathdb/journal.go
+++ b/trie/triedb/pathdb/journal.go
@@ -152,8 +152,8 @@ func (kr *JournalKVReader) Close() {
 }
 
 func newJournalWriter(file string, db ethdb.Database, journalType JournalType) JournalWriter {
-	log.Info("New journal writer", "path", file, "journalType", journalType)
 	if journalType == JournalKVType {
+		log.Info("New journal writer for journal kv")
 		return &JournalKVWriter{
 			diskdb: db,
 		}
@@ -162,6 +162,7 @@ func newJournalWriter(file string, db ethdb.Database, journalType JournalType) J
 		if err != nil {
 			return nil
 		}
+		log.Info("New journal writer for journal file", "path", file)
 		return &JournalFileWriter{
 			file: fd,
 		}
@@ -169,12 +170,13 @@ func newJournalWriter(file string, db ethdb.Database, journalType JournalType) J
 }
 
 func newJournalReader(file string, db ethdb.Database, journalType JournalType) (JournalReader, error) {
-	log.Info("New journal reader", "path", file, "journalType", journalType)
 	if journalType == JournalKVType {
 		journal := rawdb.ReadTrieJournal(db)
 		if len(journal) == 0 {
 			return nil, errMissJournal
 		}
+
+		log.Info("New journal reader for journal kv")
 		return &JournalKVReader{
 			journalBuf: bytes.NewBuffer(journal),
 		}, nil
@@ -186,6 +188,7 @@ func newJournalReader(file string, db ethdb.Database, journalType JournalType) (
 		if err != nil {
 			return nil, err
 		}
+		log.Info("New journal reader for journal file", "path", file)
 		return &JournalFileReader{
 			file: fd,
 		}, nil

--- a/trie/triedb/pathdb/journal.go
+++ b/trie/triedb/pathdb/journal.go
@@ -18,15 +18,19 @@ package pathdb
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie/trienode"
@@ -70,13 +74,134 @@ type journalStorage struct {
 	Slots      [][]byte
 }
 
+type JournalWriter interface {
+	io.Writer
+
+	Close()
+	Size() uint64
+}
+
+type JournalReader interface {
+	io.Reader
+	Close()
+}
+
+type JournalFileWriter struct {
+	file *os.File
+}
+
+type JournalFileReader struct {
+	file *os.File
+}
+
+type JournalKVWriter struct {
+	journalBuf bytes.Buffer
+	diskdb     ethdb.Database
+}
+
+type JournalKVReader struct {
+	journalBuf *bytes.Buffer
+}
+
+// Write appends b directly to the encoder output.
+func (fw *JournalFileWriter) Write(b []byte) (int, error) {
+	return fw.file.Write(b)
+}
+
+func (fw *JournalFileWriter) Close() {
+	fw.file.Close()
+}
+
+func (fw *JournalFileWriter) Size() uint64 {
+	if fw.file == nil {
+		return 0
+	}
+	fileInfo, err := fw.file.Stat()
+	if err != nil {
+		log.Crit("Failed to stat journal", "err", err)
+	}
+	return uint64(fileInfo.Size())
+}
+
+func (kw *JournalKVWriter) Write(b []byte) (int, error) {
+	return kw.journalBuf.Write(b)
+}
+
+func (kw *JournalKVWriter) Close() {
+	rawdb.WriteTrieJournal(kw.diskdb, kw.journalBuf.Bytes())
+	kw.journalBuf.Reset()
+}
+
+func (kw *JournalKVWriter) Size() uint64 {
+	return uint64(kw.journalBuf.Len())
+}
+
+func (fr *JournalFileReader) Read(p []byte) (n int, err error) {
+	return fr.file.Read(p)
+}
+
+func (fr *JournalFileReader) Close() {
+	fr.file.Close()
+}
+
+func (kr *JournalKVReader) Read(p []byte) (n int, err error) {
+	return kr.journalBuf.Read(p)
+}
+
+func (kr *JournalKVReader) Close() {
+}
+
+func newJournalWriter(file string, db ethdb.Database) JournalWriter {
+	if len(file) == 0 {
+		return &JournalKVWriter{
+			diskdb: db,
+		}
+	} else {
+		fd, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			return nil
+		}
+		return &JournalFileWriter{
+			file: fd,
+		}
+	}
+}
+
+func newJournalReader(file string, db ethdb.Database) (JournalReader, error) {
+	if len(file) == 0 {
+		journal := rawdb.ReadTrieJournal(db)
+		if len(journal) == 0 {
+			return nil, errMissJournal
+		}
+		return &JournalKVReader{
+			journalBuf: bytes.NewBuffer(journal),
+		}, nil
+	} else {
+		fd, err := os.Open(file)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, errMissJournal
+		}
+		if err != nil {
+			return nil, err
+		}
+		return &JournalFileReader{
+			file: fd,
+		}, nil
+	}
+}
+
 // loadJournal tries to parse the layer journal from the disk.
 func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
-	journal := rawdb.ReadTrieJournal(db.diskdb)
-	if len(journal) == 0 {
-		return nil, errMissJournal
+	start := time.Now()
+	reader, err := newJournalReader(db.config.JournalFilePath, db.diskdb)
+
+	if err != nil {
+		return nil, err
 	}
-	r := rlp.NewStream(bytes.NewReader(journal), 0)
+	if reader != nil {
+		defer reader.Close()
+	}
+	r := rlp.NewStream(reader, 0)
 
 	// Firstly, resolve the first element as the journal version
 	version, err := r.Uint64()
@@ -108,7 +233,7 @@ func (db *Database) loadJournal(diskRoot common.Hash) (layer, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("Loaded layer journal", "diskroot", diskRoot, "diffhead", head.rootHash())
+	log.Info("Loaded layer journal", "diskroot", diskRoot, "diffhead", head.rootHash(), "elapsed", common.PrettyDuration(time.Since(start)))
 	return head, nil
 }
 
@@ -141,14 +266,25 @@ func (db *Database) loadLayers() layer {
 func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 	// Resolve disk layer root
 	var root common.Hash
-	if err := r.Decode(&root); err != nil {
+	var length uint64
+	if err := r.Decode(&length); err != nil {
+		return nil, fmt.Errorf("load disk length: %v", err)
+	}
+
+	var journalEncodedBuff []byte
+	if err := r.Decode(&journalEncodedBuff); err != nil {
+		return nil, fmt.Errorf("load disk journal: %v", err)
+	}
+
+	journalBuf := rlp.NewStream(bytes.NewReader(journalEncodedBuff), 0)
+	if err := journalBuf.Decode(&root); err != nil {
 		return nil, fmt.Errorf("load disk root: %v", err)
 	}
 	// Resolve the state id of disk layer, it can be different
 	// with the persistent id tracked in disk, the id distance
 	// is the number of transitions aggregated in disk layer.
 	var id uint64
-	if err := r.Decode(&id); err != nil {
+	if err := journalBuf.Decode(&id); err != nil {
 		return nil, fmt.Errorf("load state id: %v", err)
 	}
 	stored := rawdb.ReadPersistentStateID(db.diskdb)
@@ -157,7 +293,7 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 	}
 	// Resolve nodes cached in node buffer
 	var encoded []journalNodes
-	if err := r.Decode(&encoded); err != nil {
+	if err := journalBuf.Decode(&encoded); err != nil {
 		return nil, fmt.Errorf("load disk nodes: %v", err)
 	}
 	nodes := make(map[common.Hash]map[string]*trienode.Node)
@@ -172,6 +308,17 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 		}
 		nodes[entry.Owner] = subset
 	}
+
+	var shaSum [32]byte
+	if err := r.Decode(&shaSum); err != nil {
+		return nil, fmt.Errorf("load shasum: %v", err)
+	}
+
+	expectSum := sha256.Sum256(journalEncodedBuff)
+	if shaSum != expectSum {
+		return nil, fmt.Errorf("expect shaSum: %v, real:%v", expectSum, shaSum)
+	}
+
 	// Calculate the internal state transitions by id difference.
 	nb := NewTrieNodeBuffer(db.diskdb, db.config.TrieNodeBufferType, db.bufferSize, nodes, id-stored, db.config.ProposeBlockInterval, db.config.NotifyKeep)
 	base := newDiskLayer(root, id, db, nil, nb)
@@ -184,7 +331,22 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 	// Read the next diff journal entry
 	var root common.Hash
-	if err := r.Decode(&root); err != nil {
+	var length uint64
+	if err := r.Decode(&length); err != nil {
+		// The first read may fail with EOF, marking the end of the journal
+		if err == io.EOF {
+			return parent, nil
+		}
+		return nil, fmt.Errorf("load disk length : %v", err)
+	}
+	var journalEncodedBuff []byte
+	if err := r.Decode(&journalEncodedBuff); err != nil {
+		return nil, fmt.Errorf("load disk journal buffer: %v", err)
+	}
+
+	journalBuf := rlp.NewStream(bytes.NewReader(journalEncodedBuff), 0)
+
+	if err := journalBuf.Decode(&root); err != nil {
 		// The first read may fail with EOF, marking the end of the journal
 		if err == io.EOF {
 			return parent, nil
@@ -192,12 +354,12 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		return nil, fmt.Errorf("load diff root: %v", err)
 	}
 	var block uint64
-	if err := r.Decode(&block); err != nil {
+	if err := journalBuf.Decode(&block); err != nil {
 		return nil, fmt.Errorf("load block number: %v", err)
 	}
 	// Read in-memory trie nodes from journal
 	var encoded []journalNodes
-	if err := r.Decode(&encoded); err != nil {
+	if err := journalBuf.Decode(&encoded); err != nil {
 		return nil, fmt.Errorf("load diff nodes: %v", err)
 	}
 	nodes := make(map[common.Hash]map[string]*trienode.Node)
@@ -220,13 +382,13 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		storages   = make(map[common.Address]map[common.Hash][]byte)
 		incomplete = make(map[common.Address]struct{})
 	)
-	if err := r.Decode(&jaccounts); err != nil {
+	if err := journalBuf.Decode(&jaccounts); err != nil {
 		return nil, fmt.Errorf("load diff accounts: %v", err)
 	}
 	for i, addr := range jaccounts.Addresses {
 		accounts[addr] = jaccounts.Accounts[i]
 	}
-	if err := r.Decode(&jstorages); err != nil {
+	if err := journalBuf.Decode(&jstorages); err != nil {
 		return nil, fmt.Errorf("load diff storages: %v", err)
 	}
 	for _, entry := range jstorages {
@@ -243,6 +405,17 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		}
 		storages[entry.Account] = set
 	}
+	var shaSum [32]byte
+	if err := r.Decode(&shaSum); err != nil {
+		return nil, fmt.Errorf("load shasum: %v", err)
+	}
+
+	expectSum := sha256.Sum256(journalEncodedBuff)
+	if shaSum != expectSum {
+		return nil, fmt.Errorf("expect shaSum: %v, real:%v", expectSum, shaSum)
+	}
+	log.Debug("Loaded diff layer journal", "root", root, "parent", parent.rootHash(), "id", parent.stateID()+1, "block", block)
+
 	return db.loadDiffLayer(newDiffLayer(parent, root, parent.stateID()+1, block, nodes, triestate.New(accounts, storages, incomplete)), r)
 }
 
@@ -252,16 +425,19 @@ func (dl *diskLayer) journal(w io.Writer) error {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
+	// Create a buffer to store encoded data
+	journalBuf := new(bytes.Buffer)
+
 	// Ensure the layer didn't get stale
 	if dl.stale {
 		return errSnapshotStale
 	}
 	// Step one, write the disk root into the journal.
-	if err := rlp.Encode(w, dl.root); err != nil {
+	if err := rlp.Encode(journalBuf, dl.root); err != nil {
 		return err
 	}
 	// Step two, write the corresponding state id into the journal
-	if err := rlp.Encode(w, dl.id); err != nil {
+	if err := rlp.Encode(journalBuf, dl.id); err != nil {
 		return err
 	}
 	// Step three, write all unwritten nodes into the journal
@@ -274,10 +450,22 @@ func (dl *diskLayer) journal(w io.Writer) error {
 		}
 		nodes = append(nodes, entry)
 	}
-	if err := rlp.Encode(w, nodes); err != nil {
+	if err := rlp.Encode(journalBuf, nodes); err != nil {
 		return err
 	}
-	log.Debug("Journaled pathdb disk layer", "root", dl.root, "nodes", len(bufferNodes))
+
+	// Store the journal buf into w and calculate checksum
+	if err := rlp.Encode(w, uint64(journalBuf.Len())); err != nil {
+		return err
+	}
+	shasum := sha256.Sum256(journalBuf.Bytes())
+	if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
+		return err
+	}
+	if err := rlp.Encode(w, shasum); err != nil {
+		return err
+	}
+	log.Info("Journaled pathdb disk layer", "root", dl.root, "nodes", len(bufferNodes))
 	return nil
 }
 
@@ -291,11 +479,13 @@ func (dl *diffLayer) journal(w io.Writer) error {
 	if err := dl.parent.journal(w); err != nil {
 		return err
 	}
+	// Create a buffer to store encoded data
+	journalBuf := new(bytes.Buffer)
 	// Everything below was journaled, persist this layer too
-	if err := rlp.Encode(w, dl.root); err != nil {
+	if err := rlp.Encode(journalBuf, dl.root); err != nil {
 		return err
 	}
-	if err := rlp.Encode(w, dl.block); err != nil {
+	if err := rlp.Encode(journalBuf, dl.block); err != nil {
 		return err
 	}
 	// Write the accumulated trie nodes into buffer
@@ -307,7 +497,7 @@ func (dl *diffLayer) journal(w io.Writer) error {
 		}
 		nodes = append(nodes, entry)
 	}
-	if err := rlp.Encode(w, nodes); err != nil {
+	if err := rlp.Encode(journalBuf, nodes); err != nil {
 		return err
 	}
 	// Write the accumulated state changes into buffer
@@ -316,7 +506,7 @@ func (dl *diffLayer) journal(w io.Writer) error {
 		jacct.Addresses = append(jacct.Addresses, addr)
 		jacct.Accounts = append(jacct.Accounts, account)
 	}
-	if err := rlp.Encode(w, jacct); err != nil {
+	if err := rlp.Encode(journalBuf, jacct); err != nil {
 		return err
 	}
 	storage := make([]journalStorage, 0, len(dl.states.Storages))
@@ -331,10 +521,22 @@ func (dl *diffLayer) journal(w io.Writer) error {
 		}
 		storage = append(storage, entry)
 	}
-	if err := rlp.Encode(w, storage); err != nil {
+	if err := rlp.Encode(journalBuf, storage); err != nil {
 		return err
 	}
-	log.Debug("Journaled pathdb diff layer", "root", dl.root, "parent", dl.parent.rootHash(), "id", dl.stateID(), "block", dl.block, "nodes", len(dl.nodes))
+
+	// Store the journal buf into w and calculate checksum
+	if err := rlp.Encode(w, uint64(journalBuf.Len())); err != nil {
+		return err
+	}
+	shasum := sha256.Sum256(journalBuf.Bytes())
+	if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
+		return err
+	}
+	if err := rlp.Encode(w, shasum); err != nil {
+		return err
+	}
+	log.Info("Journaled pathdb diff layer", "root", dl.root, "parent", dl.parent.rootHash(), "id", dl.stateID(), "block", dl.block, "nodes", len(dl.nodes))
 	return nil
 }
 
@@ -367,7 +569,10 @@ func (db *Database) Journal(root common.Hash) error {
 		return errDatabaseReadOnly
 	}
 	// Firstly write out the metadata of journal
-	journal := new(bytes.Buffer)
+	db.DeleteTrieJournal(db.diskdb)
+	journal := newJournalWriter(db.config.JournalFilePath, db.diskdb)
+	defer journal.Close()
+
 	if err := rlp.Encode(journal, journalVersion); err != nil {
 		return err
 	}
@@ -386,10 +591,10 @@ func (db *Database) Journal(root common.Hash) error {
 		return err
 	}
 	// Store the journal into the database and return
-	rawdb.WriteTrieJournal(db.diskdb, journal.Bytes())
+	journalSize := journal.Size()
 
 	// Set the db in read only mode to reject all following mutations
 	db.readOnly = true
-	log.Info("Persisted dirty state to disk", "size", common.StorageSize(journal.Len()), "elapsed", common.PrettyDuration(time.Since(start)))
+	log.Info("Persisted dirty state to disk", "size", common.StorageSize(journalSize), "elapsed", common.PrettyDuration(time.Since(start)))
 	return nil
 }

--- a/trie/triedb/pathdb/journal.go
+++ b/trie/triedb/pathdb/journal.go
@@ -265,18 +265,20 @@ func (db *Database) loadLayers() layer {
 // a new disk layer on it.
 func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 	// Resolve disk layer root
-	var root common.Hash
-	var length uint64
-	if err := r.Decode(&length); err != nil {
-		return nil, fmt.Errorf("load disk length: %v", err)
+	var (
+		root               common.Hash
+		journalBuf         *rlp.Stream
+		journalEncodedBuff []byte
+	)
+	if db.IsEnableJournalFile() {
+		if err := r.Decode(&journalEncodedBuff); err != nil {
+			return nil, fmt.Errorf("load disk journal: %v", err)
+		}
+		journalBuf = rlp.NewStream(bytes.NewReader(journalEncodedBuff), 0)
+	} else {
+		journalBuf = r
 	}
 
-	var journalEncodedBuff []byte
-	if err := r.Decode(&journalEncodedBuff); err != nil {
-		return nil, fmt.Errorf("load disk journal: %v", err)
-	}
-
-	journalBuf := rlp.NewStream(bytes.NewReader(journalEncodedBuff), 0)
 	if err := journalBuf.Decode(&root); err != nil {
 		return nil, fmt.Errorf("load disk root: %v", err)
 	}
@@ -309,14 +311,16 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 		nodes[entry.Owner] = subset
 	}
 
-	var shaSum [32]byte
-	if err := r.Decode(&shaSum); err != nil {
-		return nil, fmt.Errorf("load shasum: %v", err)
-	}
+	if db.IsEnableJournalFile() {
+		var shaSum [32]byte
+		if err := r.Decode(&shaSum); err != nil {
+			return nil, fmt.Errorf("load shasum: %v", err)
+		}
 
-	expectSum := sha256.Sum256(journalEncodedBuff)
-	if shaSum != expectSum {
-		return nil, fmt.Errorf("expect shaSum: %v, real:%v", expectSum, shaSum)
+		expectSum := sha256.Sum256(journalEncodedBuff)
+		if shaSum != expectSum {
+			return nil, fmt.Errorf("expect shaSum: %v, real:%v", expectSum, shaSum)
+		}
 	}
 
 	// Calculate the internal state transitions by id difference.
@@ -330,21 +334,23 @@ func (db *Database) loadDiskLayer(r *rlp.Stream) (layer, error) {
 // diff and verifying that it can be linked to the requested parent.
 func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 	// Read the next diff journal entry
-	var root common.Hash
-	var length uint64
-	if err := r.Decode(&length); err != nil {
-		// The first read may fail with EOF, marking the end of the journal
-		if err == io.EOF {
-			return parent, nil
+	var (
+		root               common.Hash
+		journalBuf         *rlp.Stream
+		journalEncodedBuff []byte
+	)
+	if db.IsEnableJournalFile() {
+		if err := r.Decode(&journalEncodedBuff); err != nil {
+			// The first read may fail with EOF, marking the end of the journal
+			if err == io.EOF {
+				return parent, nil
+			}
+			return nil, fmt.Errorf("load disk journal buffer: %v", err)
 		}
-		return nil, fmt.Errorf("load disk length : %v", err)
+		journalBuf = rlp.NewStream(bytes.NewReader(journalEncodedBuff), 0)
+	} else {
+		journalBuf = r
 	}
-	var journalEncodedBuff []byte
-	if err := r.Decode(&journalEncodedBuff); err != nil {
-		return nil, fmt.Errorf("load disk journal buffer: %v", err)
-	}
-
-	journalBuf := rlp.NewStream(bytes.NewReader(journalEncodedBuff), 0)
 
 	if err := journalBuf.Decode(&root); err != nil {
 		// The first read may fail with EOF, marking the end of the journal
@@ -405,23 +411,27 @@ func (db *Database) loadDiffLayer(parent layer, r *rlp.Stream) (layer, error) {
 		}
 		storages[entry.Account] = set
 	}
-	var shaSum [32]byte
-	if err := r.Decode(&shaSum); err != nil {
-		return nil, fmt.Errorf("load shasum: %v", err)
+
+	if db.IsEnableJournalFile() {
+		var shaSum [32]byte
+		if err := r.Decode(&shaSum); err != nil {
+			return nil, fmt.Errorf("load shasum: %v", err)
+		}
+
+		expectSum := sha256.Sum256(journalEncodedBuff)
+		if shaSum != expectSum {
+			return nil, fmt.Errorf("expect shaSum: %v, real:%v", expectSum, shaSum)
+		}
 	}
 
-	expectSum := sha256.Sum256(journalEncodedBuff)
-	if shaSum != expectSum {
-		return nil, fmt.Errorf("expect shaSum: %v, real:%v", expectSum, shaSum)
-	}
 	log.Debug("Loaded diff layer journal", "root", root, "parent", parent.rootHash(), "id", parent.stateID()+1, "block", block)
 
 	return db.loadDiffLayer(newDiffLayer(parent, root, parent.stateID()+1, block, nodes, triestate.New(accounts, storages, incomplete)), r)
 }
 
 // journal implements the layer interface, marshaling the un-flushed trie nodes
-// along with layer meta data into provided byte buffer.
-func (dl *diskLayer) journal(w io.Writer) error {
+// along with layer metadata into provided byte buffer.
+func (dl *diskLayer) journal(w io.Writer, journalFile bool) error {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
@@ -455,28 +465,32 @@ func (dl *diskLayer) journal(w io.Writer) error {
 	}
 
 	// Store the journal buf into w and calculate checksum
-	if err := rlp.Encode(w, uint64(journalBuf.Len())); err != nil {
-		return err
+	if journalFile {
+		shasum := sha256.Sum256(journalBuf.Bytes())
+		if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
+			return err
+		}
+		if err := rlp.Encode(w, shasum); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(journalBuf.Bytes()); err != nil {
+			return err
+		}
 	}
-	shasum := sha256.Sum256(journalBuf.Bytes())
-	if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
-		return err
-	}
-	if err := rlp.Encode(w, shasum); err != nil {
-		return err
-	}
+
 	log.Info("Journaled pathdb disk layer", "root", dl.root, "nodes", len(bufferNodes))
 	return nil
 }
 
 // journal implements the layer interface, writing the memory layer contents
 // into a buffer to be stored in the database as the layer journal.
-func (dl *diffLayer) journal(w io.Writer) error {
+func (dl *diffLayer) journal(w io.Writer, journalFile bool) error {
 	dl.lock.RLock()
 	defer dl.lock.RUnlock()
 
 	// journal the parent first
-	if err := dl.parent.journal(w); err != nil {
+	if err := dl.parent.journal(w, journalFile); err != nil {
 		return err
 	}
 	// Create a buffer to store encoded data
@@ -526,16 +540,20 @@ func (dl *diffLayer) journal(w io.Writer) error {
 	}
 
 	// Store the journal buf into w and calculate checksum
-	if err := rlp.Encode(w, uint64(journalBuf.Len())); err != nil {
-		return err
+	if journalFile {
+		shasum := sha256.Sum256(journalBuf.Bytes())
+		if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
+			return err
+		}
+		if err := rlp.Encode(w, shasum); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(journalBuf.Bytes()); err != nil {
+			return err
+		}
 	}
-	shasum := sha256.Sum256(journalBuf.Bytes())
-	if err := rlp.Encode(w, journalBuf.Bytes()); err != nil {
-		return err
-	}
-	if err := rlp.Encode(w, shasum); err != nil {
-		return err
-	}
+
 	log.Info("Journaled pathdb diff layer", "root", dl.root, "parent", dl.parent.rootHash(), "id", dl.stateID(), "block", dl.block, "nodes", len(dl.nodes))
 	return nil
 }
@@ -587,7 +605,7 @@ func (db *Database) Journal(root common.Hash) error {
 		return err
 	}
 	// Finally write out the journal of each layer in reverse order.
-	if err := l.journal(journal); err != nil {
+	if err := l.journal(journal, db.IsEnableJournalFile()); err != nil {
 		return err
 	}
 	// Store the journal into the database and return

--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -727,7 +727,7 @@ func (w *proposedBlockReader) parentLayer() layer { return nil }
 func (w *proposedBlockReader) update(root common.Hash, id uint64, block uint64, nodes map[common.Hash]map[string]*trienode.Node, states *triestate.Set) *diffLayer {
 	return nil
 }
-func (w *proposedBlockReader) journal(io.Writer) error { return nil }
+func (w *proposedBlockReader) journal(io.Writer, bool) error { return nil }
 
 // multiDifflayer compresses several difflayers in one map. As an element of nodebufferlist
 // it is the smallest unit for storing trie nodes.

--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -727,7 +727,7 @@ func (w *proposedBlockReader) parentLayer() layer { return nil }
 func (w *proposedBlockReader) update(root common.Hash, id uint64, block uint64, nodes map[common.Hash]map[string]*trienode.Node, states *triestate.Set) *diffLayer {
 	return nil
 }
-func (w *proposedBlockReader) journal(io.Writer, bool) error { return nil }
+func (w *proposedBlockReader) journal(io.Writer, JournalType) error { return nil }
 
 // multiDifflayer compresses several difflayers in one map. As an element of nodebufferlist
 // it is the smallest unit for storing trie nodes.


### PR DESCRIPTION
### Description

This PR provides another way to persist TrieJournal by write it into a log file instead of a kv database.

Use `--journalFile` flag to enable/disable the journal file feature.

### Rationale

Persisting TrieJournal to KV database will cause problems below

- Additional WAL and compaction overhead in pebble/leveldb
- Big kv (>= 2GB) not supported by pebbledb. ([Size out of bounds when write kv >= 2GB](https://github.com/cockroachdb/pebble/issues/3333))

### Changes:

**Data Format**

Journal Version
Disk Root
Disk Layer
- Root
- State ID
- Buffer Nodes
- `Layer Checksum`

Diff Layer

- Root
- Block
- Trie Nodes
- Journal Accounts
- `Layer Checksum`

Journal Path: geth/chaindata/ancient/state.journal
Checksum: SHA256

####  Performance test

Scenario: Using TestJournal, each layer has 4K and 8K account operations.
|            | WriteJournal | LoadJournal | Dirty State Size | 
|------------|--------------|-------------|------------------| 
| **New Journal WAL** | 6.149s | 12.496s | 1.19GiB | 
| Old KVDB        | 6.341s | 12.340s | 1.21GiB | 
| **New Journal WAL** | 11.724s | 20.525s | 1.85GiB | 
| Old KVDB        | 11.107s | 19.415s | 1.85GiB |  

Conclusion: The use of Journal WAL and storing trieJournalKey directly into kvdb results in nearly identical WAL write times during shutdown and WAL read/parsing times during startup.
