### PR TITLE
canyon fork: revert disable create2deployer in canyon fork

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -79,8 +79,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		misc.ApplyPreContractHardFork(statedb)
 	}
 
-	// opBNB no need to hard code this contract via hardfork
-	// misc.EnsureCreate2Deployer(p.config, block.Time(), statedb)
+	misc.EnsureCreate2Deployer(p.config, block.Time(), statedb)
 
 	var (
 		context = NewEVMBlockContext(header, p.bc, nil, p.config, statedb)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1147,8 +1147,7 @@ func (w *worker) generateWork(genParams *generateParams) *newPayloadResult {
 		misc.ApplyPreContractHardFork(work.state)
 	}
 
-	// opBNB no need to hard code this contract via hardfork
-	// misc.EnsureCreate2Deployer(w.chainConfig, work.header.Time, work.state)
+	misc.EnsureCreate2Deployer(w.chainConfig, work.header.Time, work.state)
 
 	start := time.Now()
 	for _, tx := range genParams.txs {


### PR DESCRIPTION
### Description

 revert disable create2deployer in canyon fork
### Rationale

create2deployer is a precontract now in upstream, we better consist with it
### Example

n/a
### Changes

 revert disable create2deployer in canyon fork

