### PR TITLE
add precompiled contracts for light client

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -127,6 +127,9 @@ var PrecompiledContractsCancun = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{8}):    &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{9}):    &blake2F{},
 	common.BytesToAddress([]byte{0x0a}): &kzgPointEvaluation{},
+
+	common.BytesToAddress([]byte{102}): &blsSignatureVerify{},
+	common.BytesToAddress([]byte{103}): &cometBFTLightBlockValidate{},
 }
 
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum


### PR DESCRIPTION
### Description

add precompiled contracts for light client validation

### Rationale

The precompiled contracts for light client validation should not be removed here.

### Example

NA

### Changes

Notable changes:
* NA
