### PR TITLE
feature: add opBNB V5 bootnodes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1186,7 +1186,7 @@ func mustParseBootnodes(urls []string) []*enode.Node {
 // setBootstrapNodesV5 creates a list of bootstrap nodes from the command line
 // flags, reverting to pre-configured ones if none have been specified.
 func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
-	urls := params.V5Bootnodes
+	urls := params.OpBNBMainnetBootnodes
 	switch {
 	case ctx.IsSet(BootnodesFlag.Name):
 		urls = SplitAndTrim(ctx.String(BootnodesFlag.Name))
@@ -1198,6 +1198,12 @@ func setBootstrapNodesV5(ctx *cli.Context, cfg *p2p.Config) {
 			urls = append(urls, params.OPMainnetBootnodes...)
 		} else {
 			urls = append(urls, params.OPSepoliaBootnodes...)
+		}
+	case ctx.Bool(OpBNBTestnetFlag.Name):
+		urls = params.OpBNBTestnetBootnodes
+	case ctx.Bool(NetworkIdFlag.Name):
+		if ctx.Uint64(NetworkIdFlag.Name) == params.OpBNBTestnet {
+			urls = params.OpBNBTestnetBootnodes
 		}
 	}
 


### PR DESCRIPTION
### Description

Add `opBNB` testnet and mainnet V5 bootnodes in code.

### Rationale

Add `opBNB` testnet and mainnet V5 bootnodes in code can facilitate the startup of new nodes.

### Example

The startup node will use the `opBNB` mainnet's V5 bootnodes by default. If the `--opBNBTestnet`  is configured the testnet V5 bootnodes will be used. If the `--networkid` is configured and it is testnet, the testnet V5 bootnodes will be used. If `--bootnodes` is configured, the configured bootnodes will be used. The configured `--bootnodes` have the highest priority. The `--networkid` have the lowest priority.

### Changes

Notable changes:
* Add `opBNB` testnet and mainnet V5 bootnodes in code can facilitate the startup of new nodes.
