### PR TITLE
fix: the TrieCommitInterval not taking effect on restart

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1046,7 +1046,15 @@ func (bc *BlockChain) Stop() {
 		if !bc.cacheConfig.TrieDirtyDisabled {
 			triedb := bc.triedb
 
-			for _, offset := range []uint64{0, 1, TriesInMemory - 1} {
+			blockOffsets := []uint64{0, 1, TriesInMemory - 1}
+			if bc.cacheConfig.TrieCommitInterval != 0 {
+				current := bc.CurrentBlock().Number.Uint64()
+				blockShouldCommitOffset := current - current/bc.cacheConfig.TrieCommitInterval*bc.cacheConfig.TrieCommitInterval
+				if blockShouldCommitOffset > 1 && blockShouldCommitOffset < TriesInMemory-1 {
+					blockOffsets = append(blockOffsets, blockShouldCommitOffset)
+				}
+			}
+			for _, offset := range blockOffsets {
 				if number := bc.CurrentBlock().Number.Uint64(); number > offset {
 					recent := bc.GetBlockByNumber(number - offset)
 


### PR DESCRIPTION
### Description

In https://github.com/bnb-chain/op-geth/pull/45, I added a TrieCommitInterval parameter for periodically committing trie data for specific block heights when gcMode=full. However, I missed an extreme case during restart where the block height that needs to be committed is within a range of 128 block heights, causing the data to be lost from memory and not recovered upon restarting. We need to fix this problem.

### Rationale

In the Stop function, the data of the latest block height minus 0, the latest block height minus 1, and the latest block height minus 127 will be automatically committed.
If TrieCommitInterval is not equal to 0, then I will calculate an additional offset, so that the code can automatically commit the data of the block height specified by TrieCommitInterval.

### Example

none

### Changes

Notable changes:
* Add additional logic related to TrieCommitInterval in the Stop function.
