### PR TITLE
fix: cherry-picked from upstream code

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -58,7 +58,7 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	p, ok := precompiles[addr]
 	// Restrict overrides to known precompiles
 	if ok && evm.chainConfig.IsOptimism() && evm.Config.OptimismPrecompileOverrides != nil {
-		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, addr)
+		override, ok := evm.Config.OptimismPrecompileOverrides(evm.chainRules, p, addr)
 		if ok {
 			return override, ok
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -25,7 +25,7 @@ import (
 )
 
 // PrecompileOverrides is a function that can be used to override the default precompiled contracts
-type PrecompileOverrides func(params.Rules, common.Address) (PrecompiledContract, bool)
+type PrecompileOverrides func(params.Rules, PrecompiledContract, common.Address) (PrecompiledContract, bool)
 
 // Config are the configuration options for the Interpreter
 type Config struct {


### PR DESCRIPTION
### Description

When we merged version 1.7.2 of the upstream code for opbnb into our repository, this PR was missing from the content of the op-geth version it depends on. This PR was submitted in v1.101308.3, but our op-geth repository only merged the code from upstream v1.101308.2.
This PR has no impact on the block production logic, only affects the CI of the opbnb repository and the code in op-program, so there is no need for urgent repair. This is a change made to fix the CI of the opbnb repository.

### Rationale

This PR is cherry-picked from upstream code in order to fix the CI of the opbnb repository.

### Example

none

### Changes

Notable changes:
* cherry-picked upstream code
* ...
