### PR TITLE
fix: add miss cache code after 4844 merge

### DIFF
--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -350,11 +350,13 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			r := w.getSealingBlock(fullParams)
 			dur := time.Since(start)
 			// update handles error case
-			payload.update(r, dur)
+			payload.update(r, dur, func() {
+				w.cacheMiningBlock(r.block, r.env)
+			})
 			if r.err == nil {
 				// after first successful pass, we're updating
 				fullParams.isUpdate = true
-			}else {
+			} else {
 				log.Error("Failed to build full payload", "id", payload.id, "err", r.err)
 			}
 			timer.Reset(w.recommit)


### PR DESCRIPTION
### Description

During the merge process at https://github.com/bnb-chain/op-geth/pull/87, we missed a segment of code that enables caching, causing a performance decrease in geth, but it won't affect the core logic. We need to fix that code.

### Rationale

N/A

### Example

none

### Changes

Notable changes:
* Fix the missing cache enable code
