### PR TITLE
fix: adjust flush condition to avoid not flush

### DIFF
--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -128,11 +128,12 @@ func newNodeBufferList(
 		waitForceKeepCh: make(chan struct{}),
 		keepFunc:        keepFunc,
 	}
+
 	go nf.loop()
 
 	log.Info("new node buffer list", "proposed block interval", nf.wpBlocks,
 		"reserve multi difflayers", nf.rsevMdNum, "difflayers in multidifflayer", nf.dlInMd,
-		"limit", common.StorageSize(limit), "layers", layers, "persist id", nf.persistID)
+		"limit", common.StorageSize(limit), "layers", layers, "persist id", nf.persistID, "base_size", size)
 	return nf
 }
 
@@ -590,7 +591,7 @@ func (nf *nodebufferlist) loop() {
 				continue
 			}
 			nf.diffToBase()
-			if nf.base.size > nf.base.limit {
+			if nf.base.size >= nf.base.limit {
 				nf.backgroundFlush()
 			}
 			nf.isFlushing.Swap(false)


### PR DESCRIPTION
### Description

Adjust the flush condition to avoid the small probability of not flushing.

### Rationale

The diff to base condition:
https://github.com/bnb-chain/op-geth/blob/ee3412801cdd4834ac0fc03d481c96a05eddd5c8/trie/triedb/pathdb/nodebufferlist.go#L465-L469

and the background base flush condition:
https://github.com/bnb-chain/op-geth/blob/ee3412801cdd4834ac0fc03d481c96a05eddd5c8/trie/triedb/pathdb/nodebufferlist.go#L593-L595

should be consistent.

### Example

N/A.

### Changes

Notable changes:
* bufferlist.
