### PR TITLE
pathdb: handle persistent id when using nodebufferlist

### DIFF
--- a/trie/triedb/pathdb/disklayer.go
+++ b/trie/triedb/pathdb/disklayer.go
@@ -328,6 +328,9 @@ func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
 	// To remove outdated history objects from the end, we set the 'tail' parameter
 	// to 'oldest-1' due to the offset between the freezer index and the history ID.
 	if overflow {
+		if nl, ok := dl.buffer.(*nodebufferlist); ok {
+			oldest = nl.persistID - dl.db.config.StateHistory + 1
+		}
 		pruned, err := truncateFromTail(ndl.db.diskdb, ndl.db.freezer, oldest-1)
 		if err != nil {
 			return nil, err

--- a/trie/triedb/pathdb/metrics.go
+++ b/trie/triedb/pathdb/metrics.go
@@ -61,4 +61,12 @@ var (
 	baseNodeBufferDifflayerAvgSize = metrics.NewRegisteredGauge("pathdb/basenodebuffer/difflayeravgsize", nil)
 	proposedBlockReaderSuccess     = metrics.NewRegisteredMeter("pathdb/nodebufferlist/proposedblockreader/success", nil)
 	proposedBlockReaderMismatch    = metrics.NewRegisteredMeter("pathdb/nodebufferlist/proposedblockreader/mismatch", nil)
+
+	// temp metrics for test purpose
+	nblCountGauge         = metrics.NewRegisteredGauge("pathdb/nbl/count", nil)
+	nblLayersGauge        = metrics.NewRegisteredGauge("pathdb/nbl/layers", nil)
+	nblPersistIDGauge     = metrics.NewRegisteredGauge("pathdb/nbl/persistid", nil)
+	nblPrePersistIDGauge  = metrics.NewRegisteredGauge("pathdb/nbl/prepersistid", nil)
+	nblBaseLayersGauge    = metrics.NewRegisteredGauge("pathdb/nbl/baselayers", nil)
+	nblPreBaseLayersGauge = metrics.NewRegisteredGauge("pathdb/nbl/prebaselayers", nil)
 )

--- a/trie/triedb/pathdb/metrics.go
+++ b/trie/triedb/pathdb/metrics.go
@@ -61,14 +61,4 @@ var (
 	baseNodeBufferDifflayerAvgSize = metrics.NewRegisteredGauge("pathdb/basenodebuffer/difflayeravgsize", nil)
 	proposedBlockReaderSuccess     = metrics.NewRegisteredMeter("pathdb/nodebufferlist/proposedblockreader/success", nil)
 	proposedBlockReaderMismatch    = metrics.NewRegisteredMeter("pathdb/nodebufferlist/proposedblockreader/mismatch", nil)
-
-	// temp metrics for test purpose
-	nblCountGauge         = metrics.NewRegisteredGauge("pathdb/nbl/count", nil)
-	nblLayersGauge        = metrics.NewRegisteredGauge("pathdb/nbl/layers", nil)
-	nblPersistIDGauge     = metrics.NewRegisteredGauge("pathdb/nbl/persistid", nil)
-	nblPrePersistIDGauge  = metrics.NewRegisteredGauge("pathdb/nbl/prepersistid", nil)
-	nblBaseLayersGauge    = metrics.NewRegisteredGauge("pathdb/nbl/baselayers", nil)
-	nblPreBaseLayersGauge = metrics.NewRegisteredGauge("pathdb/nbl/prebaselayers", nil)
-	nblAncientSizeGauge   = metrics.NewRegisteredGauge("pathdb/nbl/ancient/size", nil)
-	nblAncientTailGauge   = metrics.NewRegisteredGauge("pathdb/nbl/ancient/tail", nil)
 )

--- a/trie/triedb/pathdb/metrics.go
+++ b/trie/triedb/pathdb/metrics.go
@@ -69,4 +69,6 @@ var (
 	nblPrePersistIDGauge  = metrics.NewRegisteredGauge("pathdb/nbl/prepersistid", nil)
 	nblBaseLayersGauge    = metrics.NewRegisteredGauge("pathdb/nbl/baselayers", nil)
 	nblPreBaseLayersGauge = metrics.NewRegisteredGauge("pathdb/nbl/prebaselayers", nil)
+	nblAncientSizeGauge   = metrics.NewRegisteredGauge("pathdb/nbl/ancient/size", nil)
+	nblAncientTailGauge   = metrics.NewRegisteredGauge("pathdb/nbl/ancient/tail", nil)
 )

--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -281,8 +281,8 @@ func (nf *nodebufferlist) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, 
 	}
 	nf.traverseReverse(commitFunc)
 	// delete after testing
-	//prePersistID := nf.persistID
-	//preBaseLayes := nf.base.layers
+	prePersistID := nf.persistID
+	preBaseLayers := nf.base.layers
 	persistID := nf.persistID + nf.base.layers
 	err := nf.base.flush(nf.db, nf.clean, persistID)
 	if err != nil {
@@ -291,6 +291,13 @@ func (nf *nodebufferlist) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, 
 	nf.isFlushing.Store(false)
 	nf.base.reset()
 	nf.persistID = persistID
+
+	nblCountGauge.Update(int64(nf.count))
+	nblLayersGauge.Update(int64(nf.layers))
+	nblPersistIDGauge.Update(int64(nf.persistID))
+	nblPrePersistIDGauge.Update(int64(prePersistID))
+	nblBaseLayersGauge.Update(int64(nf.base.layers))
+	nblPreBaseLayersGauge.Update(int64(preBaseLayers))
 	// add metrics, delete after testing
 	// 1. nf.count  nf.layers => Guard type
 	// 2. nf.persistID prePersistID => Guard type

--- a/trie/triedb/pathdb/nodebufferlist.go
+++ b/trie/triedb/pathdb/nodebufferlist.go
@@ -271,6 +271,8 @@ func (nf *nodebufferlist) flush(db ethdb.KeyValueStore, clean *fastcache.Cache, 
 
 	commitFunc := func(buffer *multiDifflayer) bool {
 		if nf.count <= nf.rsevMdNum {
+			log.Info("Skip force flush bufferlist due to bufferlist is too less",
+				"bufferlist_count", nf.count, "reserve_multi_difflayer_number", nf.rsevMdNum)
 			return false
 		}
 		if err := nf.base.commit(buffer.root, buffer.id, buffer.block, buffer.layers, buffer.nodes); err != nil {


### PR DESCRIPTION
### Description

When using nodebufferlist in pathdb, geth should maintain three node cache in memory for withdrawal proof. This pr fixes a case that when the length of history is greater than `StateHistory` but not beyond maxBufferSize, nodebufferlist still should keep three node cache.

Start a load test that uses 1000 accounts and 1TPS for about 50 hours to verify this pr, metrics are shown below:
<img width="2472" alt="image" src="https://github.com/bnb-chain/op-geth/assets/112189277/0eebeaa7-d86e-4f25-afca-dbd7cad75237">



### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* N/A
