### PR TITLE
fix: ignore truncation target range as unclean shutdown happens

### DIFF
--- a/trie/triedb/pathdb/disklayer.go
+++ b/trie/triedb/pathdb/disklayer.go
@@ -332,7 +332,7 @@ func (dl *diskLayer) commit(bottom *diffLayer, force bool) (*diskLayer, error) {
 		if _, ok := dl.buffer.(*nodebufferlist); ok {
 			persistentID := rawdb.ReadPersistentStateID(dl.db.diskdb)
 			if limit >= persistentID {
-				log.Info("No prune ancient under nodebufferlist, less than db config state history limit", "persistent_id", persistentID, "limit", limit)
+				log.Debug("No prune ancient under nodebufferlist, less than db config state history limit", "persistent_id", persistentID, "limit", limit)
 				return ndl, nil
 			}
 			targetOldest := persistentID - limit + 1

--- a/trie/triedb/pathdb/history.go
+++ b/trie/triedb/pathdb/history.go
@@ -619,7 +619,8 @@ func truncateFromTail(db ethdb.Batcher, freezer *rawdb.ResettableFreezer, ntail 
 	}
 	// Ensure that the truncation target falls within the specified range.
 	if otail > ntail || ntail > ohead {
-		return 0, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", otail, ohead, ntail)
+		log.Warn("truncate from tail out of range", "tail:", otail, "head:", ohead, "target:", ntail)
+		return 0, nil
 	}
 	// Short circuit if nothing to truncate.
 	if otail == ntail {

--- a/trie/triedb/pathdb/history_test.go
+++ b/trie/triedb/pathdb/history_test.go
@@ -252,8 +252,8 @@ func TestTruncateOutOfRange(t *testing.T) {
 		{0, head + 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, head+1)},
 		{0, tail - 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, tail-1)},
 		{1, tail, nil}, // nothing to delete
-		{1, head + 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, head+1)},
-		{1, tail - 1, fmt.Errorf("out of range, tail: %d, head: %d, target: %d", tail, head, tail-1)},
+		{1, head + 1, nil},
+		{1, tail - 1, nil},
 	}
 	for _, c := range cases {
 		var gotErr error


### PR DESCRIPTION
### Description

ignore truncation target range as unclean shutdown happens

### Rationale

bufferlist meet an update failure when unclean shutdown happens and lead to a panic, ignore the range judgement in this scenario

### Example

N/A

### Changes


