### PR TITLE
(op-geth) Add extra error info when meet an unexpected el sync

### DIFF
--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -681,6 +682,9 @@ func (api *ConsensusAPI) delayPayloadImport(block *types.Block) (engine.PayloadS
 		// that the parent state is missing and the syncer rejected extending the
 		// current cycle with the new payload.
 		log.Warn("Ignoring payload with missing parent", "number", block.NumberU64(), "hash", block.Hash(), "parent", block.ParentHash(), "reason", err)
+		if strings.Contains(err.Error(), "forced head needed for startup") {
+			return engine.PayloadStatusV1{Status: engine.SYNCING}, err
+		}
 	} else {
 		// In non-full sync mode (i.e. snap sync) all payloads are rejected until
 		// snap sync terminates as snap sync relies on direct database injections

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 	"sync"
 	"time"
 
@@ -682,7 +681,7 @@ func (api *ConsensusAPI) delayPayloadImport(block *types.Block) (engine.PayloadS
 		// that the parent state is missing and the syncer rejected extending the
 		// current cycle with the new payload.
 		log.Warn("Ignoring payload with missing parent", "number", block.NumberU64(), "hash", block.Hash(), "parent", block.ParentHash(), "reason", err)
-		if strings.Contains(err.Error(), "forced head needed for startup") {
+		if errors.Is(err, downloader.ErrForcedNeeded) {
 			return engine.PayloadStatusV1{Status: engine.SYNCING}, err
 		}
 	} else {

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -24,11 +24,14 @@ import (
 	"math/big"
 	"math/rand"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattn/go-colorable"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -50,7 +53,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/mattn/go-colorable"
 )
 
 var (
@@ -717,7 +719,7 @@ func TestEmptyBlocks(t *testing.T) {
 	payload := getNewPayload(t, api, commonAncestor, nil)
 
 	status, err := api.NewPayloadV1(*payload)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
 		t.Fatal(err)
 	}
 	if status.Status != engine.VALID {
@@ -733,7 +735,7 @@ func TestEmptyBlocks(t *testing.T) {
 	payload = setBlockhash(payload)
 	// Now latestValidHash should be the common ancestor
 	status, err = api.NewPayloadV1(*payload)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
 		t.Fatal(err)
 	}
 	if status.Status != engine.INVALID {
@@ -751,7 +753,7 @@ func TestEmptyBlocks(t *testing.T) {
 	payload = setBlockhash(payload)
 	// Now latestValidHash should be the common ancestor
 	status, err = api.NewPayloadV1(*payload)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
 		t.Fatal(err)
 	}
 	if status.Status != engine.SYNCING {
@@ -863,7 +865,7 @@ func TestTrickRemoteBlockCache(t *testing.T) {
 	// feed the payloads to node B
 	for _, payload := range invalidChain {
 		status, err := apiB.NewPayloadV1(*payload)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
 			panic(err)
 		}
 		if status.Status == engine.VALID {

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -20,11 +20,11 @@ import (
 	"bytes"
 	"context"
 	crand "crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
 	"reflect"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -719,7 +719,7 @@ func TestEmptyBlocks(t *testing.T) {
 	payload := getNewPayload(t, api, commonAncestor, nil)
 
 	status, err := api.NewPayloadV1(*payload)
-	if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
+	if err != nil && !errors.Is(err, downloader.ErrForcedNeeded) {
 		t.Fatal(err)
 	}
 	if status.Status != engine.VALID {
@@ -735,7 +735,7 @@ func TestEmptyBlocks(t *testing.T) {
 	payload = setBlockhash(payload)
 	// Now latestValidHash should be the common ancestor
 	status, err = api.NewPayloadV1(*payload)
-	if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
+	if err != nil && !errors.Is(err, downloader.ErrForcedNeeded) {
 		t.Fatal(err)
 	}
 	if status.Status != engine.INVALID {
@@ -753,7 +753,7 @@ func TestEmptyBlocks(t *testing.T) {
 	payload = setBlockhash(payload)
 	// Now latestValidHash should be the common ancestor
 	status, err = api.NewPayloadV1(*payload)
-	if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
+	if err != nil && !errors.Is(err, downloader.ErrForcedNeeded) {
 		t.Fatal(err)
 	}
 	if status.Status != engine.SYNCING {
@@ -865,7 +865,7 @@ func TestTrickRemoteBlockCache(t *testing.T) {
 	// feed the payloads to node B
 	for _, payload := range invalidChain {
 		status, err := apiB.NewPayloadV1(*payload)
-		if err != nil && !strings.Contains(err.Error(), "forced head needed for startup") {
+		if err != nil && !errors.Is(err, downloader.ErrForcedNeeded) {
 			panic(err)
 		}
 		if status.Status == engine.VALID {

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -82,6 +82,10 @@ var errChainGapped = errors.New("chain gapped")
 // of the current sync cycle is forked with the one advertised by consensus client.
 var errChainForked = errors.New("chain forked")
 
+// ErrForcedNeeded is a public error to signal that the header chain
+// of the current sync cycle needs a forced flag at startup.
+var ErrForcedNeeded = errors.New("forced head needed for startup")
+
 // maxBlockNumGapTolerance is the max gap tolerance by peer
 var maxBlockNumGapTolerance = uint64(30)
 
@@ -269,7 +273,7 @@ func (s *skeleton) startup() {
 			// New head announced, start syncing to it, looping every time a current
 			// cycle is terminated due to a chain event (head reorg, old chain merge).
 			if !event.force {
-				event.errc <- errors.New("forced head needed for startup")
+				event.errc <- ErrForcedNeeded
 				continue
 			}
 			event.errc <- nil // forced head accepted for startup


### PR DESCRIPTION
### Description

When op-geth exits due to certain exceptional circumstances and the truncate operation results in the deletion of head data, the block-by-block insertion requests from op-node will trigger an EL sync in geth. This PR addresses this situation.
related op-node pr: [https://github.com/bnb-chain/opbnb/pull/222](url)

### Rationale

Instead of ignoring the unexpected EL sync triggers, specific errors are returned. op-node will handle them based on the state.

### Example

N/A

### Changes

