### PR TITLE
feature(op-geth): add mainnet wright hard fork time

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -201,6 +201,7 @@ var (
 		CancunTime:  newUint64(1718871600), // Jun-20-2024 08:20 AM +UTC
 		EcotoneTime: newUint64(1718871600), // Jun-20-2024 08:20 AM +UTC
 		HaberTime:   newUint64(1718872200), // Jun-20-2024 08:30 AM +UTC
+		WrightTime:  newUint64(1724738400), // Aug-27-2024 06:00 AM +UTC
 	}
 	// OPBNBTestNetConfig is the chain parameters to run a node on the opBNB testnet network.
 	OPBNBTestNetConfig = &ChainConfig{


### PR DESCRIPTION
### Description

Modify the configuration to add the activation time of the `Wright` hard fork on the Mainnet.
Activation time is  2024-08-27 06:00:00 AM UTC.

### Rationale

We will activate the hard fork on the mainnet.

### Example

None

### Changes

Notable changes:
* Change the mainnet's default configuration to increase the hard fork activation time.
