### PR TITLE
PEVM-fix: avoid checkout old tx in stage2 conflict check

### DIFF
--- a/core/state/parallel_statedb.go
+++ b/core/state/parallel_statedb.go
@@ -1275,6 +1275,10 @@ func (slotDB *ParallelStateDB) IsParallelReadsValid(isStage2 bool) bool {
 	})
 
 	mainDB := slotDB.parallel.baseStateDB
+	if isStage2 && slotDB.txIndex < mainDB.TxIndex() {
+		// already merged, no need to check
+		return true
+	}
 	// for nonce
 	for addr, nonceSlot := range slotDB.parallel.nonceReadsInSlot {
 		if isStage2 { // update slotDB's unconfirmed DB list and try


### PR DESCRIPTION
### Description

The stage2 conflict check is concurrently check the Tx and stateDB, there is possibility that stateDB is updated to latest version which is newer than the tx. in this way, skip the check.

### Rationale

There can be incorrect conflict check result.


