### PR TITLE
feature(op-geth): add Fjord hard fork time

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -207,6 +207,7 @@ var (
 		EcotoneTime: newUint64(1718871600), // Jun-20-2024 08:20 AM +UTC
 		HaberTime:   newUint64(1718872200), // Jun-20-2024 08:30 AM +UTC
 		WrightTime:  newUint64(1724738400), // Aug-27-2024 06:00 AM +UTC
+		FjordTime:   newUint64(1727157600), // Sep-24-2024 06:00 AM +UTC
 	}
 	// OPBNBTestNetConfig is the chain parameters to run a node on the opBNB testnet network.
 	OPBNBTestNetConfig = &ChainConfig{
@@ -243,6 +244,7 @@ var (
 		EcotoneTime: newUint64(1715754600), // May-15-2024 06:30 AM +UTC
 		HaberTime:   newUint64(1717048800), // May-30-2024 06:00 AM +UTC
 		WrightTime:  newUint64(1723701600), // Aug-15-2024 06:00 AM +UTC
+		FjordTime:   newUint64(1725948000), // Sep-10-2024 06:00 AM +UTC
 	}
 	// OPBNBQANetConfig is the chain parameters to run a node on the opBNB qa network. It is just for internal test.
 	OPBNBQANetConfig = &ChainConfig{


### PR DESCRIPTION
### Description

Modify the configuration to add the activation time of the `Fjord` hard fork on the Testnet.
Activation time is 2024-09-10 06:00:00 AM UTC.
Modify the configuration to add the activation time of the `Fjord` hard fork on the Mainnet.
Activation time is 2024-09-24 06:00:00 AM UTC.

### Rationale

We will activate the hard fork on the testnet and mainnet.

### Example

None

### Changes

Notable changes:
* Change the testnet and mainnet's default configuration to increase the hard fork activation time.
