### PR TITLE
feat: cache lastTail in txindexer to avoid read from db

### DIFF
--- a/core/rawdb/chain_iterator_test.go
+++ b/core/rawdb/chain_iterator_test.go
@@ -162,18 +162,18 @@ func TestIndexTransactions(t *testing.T) {
 			t.Fatalf("Transaction tail mismatch")
 		}
 	}
-	IndexTransactions(chainDb, 5, 11, nil, false)
+	IndexTransactions(chainDb, 5, 11, nil, nil, false)
 	verify(5, 11, true, 5)
 	verify(0, 5, false, 5)
 
-	IndexTransactions(chainDb, 0, 5, nil, false)
+	IndexTransactions(chainDb, 0, 5, nil, nil, false)
 	verify(0, 11, true, 0)
 
-	UnindexTransactions(chainDb, 0, 5, nil, false)
+	UnindexTransactions(chainDb, 0, 5, nil, nil, false)
 	verify(5, 11, true, 5)
 	verify(0, 5, false, 5)
 
-	UnindexTransactions(chainDb, 5, 11, nil, false)
+	UnindexTransactions(chainDb, 5, 11, nil, nil, false)
 	verify(0, 11, false, 11)
 
 	// Testing corner cases
@@ -190,7 +190,7 @@ func TestIndexTransactions(t *testing.T) {
 	})
 	verify(9, 11, true, 9)
 	verify(0, 9, false, 9)
-	IndexTransactions(chainDb, 0, 9, nil, false)
+	IndexTransactions(chainDb, 0, 9, nil, nil, false)
 
 	signal = make(chan struct{})
 	var once2 sync.Once

--- a/core/txindexer_test.go
+++ b/core/txindexer_test.go
@@ -221,20 +221,20 @@ func TestTxIndexer(t *testing.T) {
 			db:       db,
 			progress: make(chan chan TxIndexProgress),
 		}
-		indexer.run(nil, 128, make(chan struct{}), make(chan struct{}))
+		indexer.run(nil, 128, nil, make(chan struct{}), make(chan struct{}))
 		verify(db, c.tailA, indexer)
 
 		indexer.limit = c.limitB
-		indexer.run(rawdb.ReadTxIndexTail(db), 128, make(chan struct{}), make(chan struct{}))
+		indexer.run(rawdb.ReadTxIndexTail(db), 128, nil, make(chan struct{}), make(chan struct{}))
 		verify(db, c.tailB, indexer)
 
 		indexer.limit = c.limitC
-		indexer.run(rawdb.ReadTxIndexTail(db), 128, make(chan struct{}), make(chan struct{}))
+		indexer.run(rawdb.ReadTxIndexTail(db), 128, nil, make(chan struct{}), make(chan struct{}))
 		verify(db, c.tailC, indexer)
 
 		// Recover all indexes
 		indexer.limit = 0
-		indexer.run(rawdb.ReadTxIndexTail(db), 128, make(chan struct{}), make(chan struct{}))
+		indexer.run(rawdb.ReadTxIndexTail(db), 128, nil, make(chan struct{}), make(chan struct{}))
 		verify(db, 0, indexer)
 
 		db.Close()


### PR DESCRIPTION
### Description
This PR fix `engine_forkchoiceUpdated` api performance issue, which is introduced from upstream geth code.

### Rationale
1. `engine_forkchoiceUpdated` api blocks on [chainHeadFeed.Send](https://github.com/bnoieh/op-geth/blob/732b95e70d919dfa7ee26010fdb5561e09ee168b/core/blockchain.go#L2460), which waits for all the feed subscribers to receive.
2. [txIndexer](https://github.com/bnoieh/op-geth/blob/0085f637eb420dbc593b4d1bd06c66e77241a6f5/core/txindexer.go#L137) is one of subscribers, it may take about 800ms to receive, and the bad apple is `rawdb.ReadTxIndexTail`. You could [find more details here](https://github.com/ethereum/go-ethereum/issues/28907)
3. opBNB block time is 1s, and can not afford this high latency of engine api


### Example
n/a
### Changes
1. cache `lastTail` in `txindexer.go` to avoid read from db
