### PR TITLE
fix(ci): support building arm64 architecture

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -43,4 +43,4 @@ jobs:
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
### Description

We need to support arm64 architecture Docker images

### Rationale

Just add the parameters `platforms: linux/amd64,linux/arm64`.

### Example

none

### Changes

Notable changes:
* docker-release.yml
