### PR TITLE
txdag: Add the dependency of read-before-write to the DAG

### DIFF
--- a/core/types/mvstates.go
+++ b/core/types/mvstates.go
@@ -915,7 +915,7 @@ func (s *MVStates) resolveDepsMapCacheByWrites(index int, reads []RWEventItem, w
 			}
 		}
 	}
-	// Looking for read operations before write operations, similar to a read->read->read/write execution sequence,
+	// Looking for read operations before write operations, e.g: read->read->read/write execution sequence,
 	// we need the write transaction to occur after the read transactions.
 	for _, item := range writes {
 		var depReads *RWTxList


### PR DESCRIPTION
### Description

We need to ensure that write transactions on the data occur after read transactions. Therefore, if there is a read transaction before a write transaction, the read transaction will be added to the dependency list.
