### PR TITLE
fix: dump command

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -516,7 +516,6 @@ func importPreimages(ctx *cli.Context) error {
 
 func parseDumpConfig(ctx *cli.Context, stack *node.Node) (*state.DumpConfig, ethdb.Database, common.Hash, error) {
 	db := utils.MakeChainDatabase(ctx, stack, true)
-	defer db.Close()
 
 	var header *types.Header
 	if ctx.NArg() > 1 {
@@ -582,6 +581,7 @@ func dump(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer db.Close()
 	triedb := utils.MakeTrieDatabase(ctx, stack, db, true, true, false) // always enable preimage lookup
 	defer triedb.Close()
 


### PR DESCRIPTION
### Description

Currently `dump` command would close db after creating it immediately

### Rationale

`dump` command is not working