### PR TITLE
fix: Fix pbss snapshot inconsistency with engine-sync enabled when starting

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -408,7 +408,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		if currentSafe != nil && currentFinalize != nil {
 			if currentSafe.Number.Uint64() > head.Number.Uint64() || currentFinalize.Number.Uint64() > head.Number.Uint64() {
 				log.Info("current unsafe is behind safe, reset")
-				bc.hc.SetHead(head.Number.Uint64(), nil, createDelFn(bc))
+				bc.HeaderChainForceSetHead(head.Number.Uint64())
 
 				// Update the safe and finalized block conditionally
 				if currentSafe.Number.Uint64() > head.Number.Uint64() {


### PR DESCRIPTION
### Description

The issue arises when PBSS snapshots are created without stopping the system, leading to inconsistencies in safe and unsafe block heights due to data persistence order. This problem occurs specifically when engine-sync is enabled, preventing proper recovery.

### Rationale

This fix addresses an issue with starting snapshots created using PBSS in specific scenarios. PBSS snapshots generated without stopping can result in inconsistencies in the safe and unsafe block heights due to the order of data persistence. In cases where engine-sync is not enabled, the existing logic can automatically recover and start. However, when engine-sync is enabled, the initialization logic prevents entry into the op-node's recovery logic. Therefore, this fix adjusts the block height relationships during Geth initialization to resolve the issue.

### Example

N/A


