### PR TITLE
perf: support new api engine_opSealPayload and optimize overheads of block mining

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -30,6 +30,12 @@ import (
 // building of the payload to commence.
 type PayloadVersion byte
 
+const (
+	GetPayloadStage  = "getPayload"
+	NewPayloadStage  = "newPayload"
+	ForkchoiceUpdate = "forkchoiceUpdate"
+)
+
 var (
 	PayloadV1 PayloadVersion = 0x1
 	PayloadV2 PayloadVersion = 0x2
@@ -179,6 +185,12 @@ type ForkchoiceStateV1 struct {
 	HeadBlockHash      common.Hash `json:"headBlockHash"`
 	SafeBlockHash      common.Hash `json:"safeBlockHash"`
 	FinalizedBlockHash common.Hash `json:"finalizedBlockHash"`
+}
+
+type OpSealPayloadResponse struct {
+	Stage         string                    `json:"stage"`
+	PayloadStatus PayloadStatusV1           `json:"payloadStatus"`
+	Payload       *ExecutionPayloadEnvelope `json:"payload"`
 }
 
 func encodeTransactions(txs []*types.Transaction) [][]byte {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -33,7 +33,7 @@ type PayloadVersion byte
 const (
 	GetPayloadStage  = "getPayload"
 	NewPayloadStage  = "newPayload"
-	ForkchoiceUpdate = "forkchoiceUpdate"
+	ForkchoiceUpdatedStage = "forkchoiceUpdated"
 )
 
 var (
@@ -188,7 +188,7 @@ type ForkchoiceStateV1 struct {
 }
 
 type OpSealPayloadResponse struct {
-	Stage         string                    `json:"stage"`
+	ErrStage      string                    `json:"errStage"`
 	PayloadStatus PayloadStatusV1           `json:"payloadStatus"`
 	Payload       *ExecutionPayloadEnvelope `json:"payload"`
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2012,12 +2012,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		stats.usedGas += usedGas
 
 		var snapDiffItems, snapBufItems common.StorageSize
-		if bc.snaps != nil {
+		if bc.snaps != nil && !minerMode {
 			snapDiffItems, snapBufItems = bc.snaps.Size()
 		}
-		var trieDiffNodes common.StorageSize = 0
-		var trieBufNodes common.StorageSize = 0
-		var trieImmutableBufNodes common.StorageSize = 0
+		
+		var trieDiffNodes, trieBufNodes, trieImmutableBufNodes common.StorageSize
 		if !minerMode {
 			trieDiffNodes, trieBufNodes, trieImmutableBufNodes, _ = bc.triedb.Size()
 		}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1708,9 +1708,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 	// Peek the error for the first block to decide the directing import logic
 	it := newInsertIterator(chain, results, bc.validator)
 
-	block := chain[0]
+	var block *types.Block
 	var err error
-	if !minerMode {
+	if minerMode {
+		block = chain[0]
+	} else {
 		block, err = it.next()
 	}
 
@@ -1868,6 +1870,15 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			continue
 		}
 
+		// Async verify header if minerMode
+		asyncItNextCh := make(chan error)
+		if minerMode {
+			go func() {
+				_, err := it.next()
+				asyncItNextCh <- err
+			}()
+		}
+
 		var (
 			receipts, receiptExist = bc.miningReceiptsCache.Get(block.Hash())
 			logs, logExist         = bc.miningTxLogsCache.Get(block.Hash())
@@ -1928,8 +1939,19 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		ptime := time.Since(pstart)
 
 		vstart := time.Now()
-		if !minerMode {
-			if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
+		// Async validate if minerMode
+		asyncValidateStateCh := make(chan error)
+		if minerMode {
+			header := block.Header()
+			// Can not validate root concurrently
+			if root := statedb.IntermediateRoot(bc.chainConfig.IsEIP158(header.Number)); header.Root != root {
+				panic(fmt.Errorf("self mined block(hash: %x number %v) verify root err(mined: %x expected: %x) dberr: %w", block.Hash(), block.NumberU64(), header.Root, root, statedb.Error()))
+			}
+			go func() {
+				asyncValidateStateCh <- bc.validator.ValidateState(block, statedb, receipts, usedGas, true)
+			}()
+		} else {
+			if err := bc.validator.ValidateState(block, statedb, receipts, usedGas, false); err != nil {
 				bc.reportBlock(block, receipts, err)
 				followupInterrupt.Store(true)
 				return it.index, err
@@ -1969,6 +1991,14 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		followupInterrupt.Store(true)
 		if err != nil {
 			return it.index, err
+		}
+		if minerMode {
+			if err := <-asyncItNextCh; err != nil {
+				panic(fmt.Errorf("self mined block(hash: %x number %v) async verify header err: %w", block.Hash(), block.NumberU64(), err))
+			}
+			if err := <-asyncValidateStateCh; err != nil {
+				panic(fmt.Errorf("self mined block(hash: %x number %v) async verify state err: %w", block.Hash(), block.NumberU64(), err))
+			}
 		}
 		bc.CacheBlock(block.Hash(), block)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1937,7 +1937,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			header := block.Header()
 			// Can not validate root concurrently
 			if root := statedb.IntermediateRoot(bc.chainConfig.IsEIP158(header.Number)); header.Root != root {
-				bc.reportBlock(block, receipts, fmt.Errorf("self mined block(hash: %x number %v) verify root err(mined: %x expected: %x) dberr: %w", block.Hash(), block.NumberU64(), header.Root, root, statedb.Error()))
+				err := fmt.Errorf("self mined block(hash: %x number %v) verify root err(mined: %x expected: %x) dberr: %w", block.Hash(), block.NumberU64(), header.Root, root, statedb.Error())
+				bc.reportBlock(block, receipts, err)
 				followupInterrupt.Store(true)
 				return it.index, err
 			}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2015,7 +2015,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		if bc.snaps != nil {
 			snapDiffItems, snapBufItems = bc.snaps.Size()
 		}
-		trieDiffNodes, trieBufNodes, trieImmutableBufNodes, _ := bc.triedb.Size()
+		var trieDiffNodes common.StorageSize = 0
+		var trieBufNodes common.StorageSize = 0
+		var trieImmutableBufNodes common.StorageSize = 0
+		if !minerMode {
+			trieDiffNodes, trieBufNodes, trieImmutableBufNodes, _ = bc.triedb.Size()
+		}
 		stats.report(chain, it.index, snapDiffItems, snapBufItems, trieDiffNodes, trieBufNodes, trieImmutableBufNodes, setHead)
 		blockGasUsedGauge.Update(int64(block.GasUsed()) / 1000000)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1141,6 +1141,13 @@ func (bc *BlockChain) procFutureBlocks() {
 	}
 }
 
+// CacheBlock cache block in memory
+func (bc *BlockChain) CacheBlock(hash common.Hash, block *types.Block) {
+	bc.hc.numberCache.Add(hash, block.NumberU64())
+	bc.hc.headerCache.Add(hash, block.Header())
+	bc.blockCache.Add(hash, block)
+}
+
 // CacheMiningReceipts cache receipts in memory
 func (bc *BlockChain) CacheMiningReceipts(hash common.Hash, receipts types.Receipts) {
 	bc.miningReceiptsCache.Add(hash, receipts)
@@ -1668,6 +1675,15 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		return 0, nil
 	}
 
+	minerMode := false
+	if len(chain) == 1 {
+		block := chain[0]
+		_, receiptExist := bc.miningReceiptsCache.Get(block.Hash())
+		_, logExist := bc.miningTxLogsCache.Get(block.Hash())
+		_, stateExist := bc.miningStateCache.Get(block.Hash())
+		minerMode = receiptExist && logExist && stateExist
+	}
+
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
 	SenderCacher.RecoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number(), chain[0].Time()), chain)
 
@@ -1691,7 +1707,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 
 	// Peek the error for the first block to decide the directing import logic
 	it := newInsertIterator(chain, results, bc.validator)
-	block, err := it.next()
+
+	block := chain[0]
+	var err error
+	if !minerMode {
+		block, err = it.next()
+	}
 
 	// Left-trim all the known blocks that don't need to build snapshot
 	if bc.skipBlock(err, it) {
@@ -1907,11 +1928,14 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		ptime := time.Since(pstart)
 
 		vstart := time.Now()
-		if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
-			bc.reportBlock(block, receipts, err)
-			followupInterrupt.Store(true)
-			return it.index, err
+		if !minerMode {
+			if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
+				bc.reportBlock(block, receipts, err)
+				followupInterrupt.Store(true)
+				return it.index, err
+			}
 		}
+
 		vtime := time.Since(vstart)
 		proctime := time.Since(start) // processing + validation
 
@@ -1946,6 +1970,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		if err != nil {
 			return it.index, err
 		}
+		bc.CacheBlock(block.Hash(), block)
+
 		// Update the metrics touched during block commit
 		accountCommitTimer.Update(statedb.AccountCommits)   // Account commits are complete, we can mark them
 		storageCommitTimer.Update(statedb.StorageCommits)   // Storage commits are complete, we can mark them
@@ -2449,10 +2475,17 @@ func (bc *BlockChain) SetCanonical(head *types.Block) (common.Hash, error) {
 			return common.Hash{}, err
 		}
 	}
-	bc.writeHeadBlock(head)
 
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		bc.writeHeadBlock(head)
+	}()
 	// Emit events
 	logs := bc.collectLogs(head, false)
+	wg.Wait()
+
 	bc.chainFeed.Send(ChainEvent{Block: head, Hash: head.Hash(), Logs: logs})
 	if len(logs) > 0 {
 		bc.logsFeed.Send(logs)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -169,7 +169,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 			blockchain.reportBlock(block, receipts, err)
 			return err
 		}
-		err = blockchain.validator.ValidateState(block, statedb, receipts, usedGas)
+		err = blockchain.validator.ValidateState(block, statedb, receipts, usedGas, false)
 		if err != nil {
 			blockchain.reportBlock(block, receipts, err)
 			return err

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1304,7 +1304,6 @@ func (s *StateDB) Commit(block uint64, deleteEmptyObjects bool) (common.Hash, er
 
 	if metrics.EnabledExpensive {
 		defer func(start time.Time) {
-			s.AccountCommits += time.Since(start)
 			accountUpdatedMeter.Mark(int64(s.AccountUpdated))
 			storageUpdatedMeter.Mark(int64(s.StorageUpdated))
 			accountDeletedMeter.Mark(int64(s.AccountDeleted))

--- a/core/types.go
+++ b/core/types.go
@@ -33,7 +33,7 @@ type Validator interface {
 
 	// ValidateState validates the given statedb and optionally the receipts and
 	// gas used.
-	ValidateState(block *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64) error
+	ValidateState(block *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64, skipRoot bool) error
 }
 
 // Prefetcher is an interface for pre-caching transaction signatures and state.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -718,6 +718,7 @@ func (api *ConsensusAPI) opSealPayload(payloadID engine.PayloadID, update engine
 	}
 
 	// TODO check update input
+	update.HeadBlockHash = payloadEnvelope.ExecutionPayload.BlockHash
 	updateResponse, err := api.forkchoiceUpdated(update, nil, engine.PayloadV3, false)
 	if err != nil || updateResponse.PayloadStatus.Status != engine.VALID {
 		log.Error("Seal payload error when forkchoiceUpdated", "error", err, "payloadStatus", updateResponse.PayloadStatus)

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -126,6 +126,23 @@ func (q *payloadQueue) has(id engine.PayloadID) bool {
 	return false
 }
 
+// getBlock retrieves block from a previously stored payload or nil if it does not exist.
+func (q *payloadQueue) getBlockByHash(hash common.Hash) *types.Block {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+
+	for _, item := range q.payloads {
+		if item == nil {
+			return nil
+		}
+		block := item.payload.GetBlock()
+		if block.Hash() == hash {
+			return block
+		}
+	}
+	return nil
+}
+
 // headerQueueItem represents an hash->header tuple to store until it's retrieved
 // or evicted.
 type headerQueueItem struct {

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -136,7 +136,7 @@ func (q *payloadQueue) getBlockByHash(hash common.Hash) *types.Block {
 			return nil
 		}
 		block := item.payload.GetBlock()
-		if block.Hash() == hash {
+		if block != nil && block.Hash() == hash {
 			return block
 		}
 	}

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -233,6 +233,15 @@ func (payload *Payload) resolve(onlyFull bool) *engine.ExecutionPayloadEnvelope 
 	return nil
 }
 
+func (payload *Payload) GetBlock() *types.Block {
+	if payload.full != nil {
+		return payload.full
+	} else if payload.empty != nil {
+		return payload.empty
+	}
+	return nil
+}
+
 // interruptBuilding sets an interrupt for a potentially ongoing
 // block building process.
 // This will prevent it from adding new transactions to the block, and if it is


### PR DESCRIPTION
### Description

This PR adds two changes to op-geth:
1. support new api engine_opSealPayload, this is the associated PR to https://github.com/bnb-chain/opbnb/pull/248
2. optimize several overheads in block mining to achieve higher TPS
### Rationale
Through load test, we found that it took about 200ms(10k tps case) to call/serve of engine apis and some overheads in block minting steps can be optimized. So we try to optimize it to achieve higher TPS.

### Example

n/a

### Changes

Notable changes:
* support new api engine_opSealPayload
```
# original block produce flow
1. op-node call engine_forkchoiceUpdated
2. wait scheduled time
3. op-node call sequentially: engine_getPayload -> engine_newPayload -> engine_forkchoiceUpdated

# new block produce flow using new engine_opSealPayload API
1. op-node call engine_forkchoiceUpdated
2. wait scheduled time
3. op-node call concurrently: engine_opSealPayloadResponse & engine_getPayload
```
* optimized points in block mining steps
```
1. Build / FinalizeAndAssemble step: concurrent IntermediateRoot   and NewBlockWithWithdrawals
2. NewPayload / ExecutableDataToBlock step: cache Block in GetPayload API then get from cache instead of ExecutableDataToBlock
3. NewPayload / it.next(validateHead inside) step:  skip it.next if in minerMode
4. NewPayload / ValidateState step: async running ValidateState
5. ForkchoiceUpdate Head / getBlockByHash step: cache block in NewPayload then get from cache
6. ForkchoiceUpdate Head / setCanoncial step: concurrent writeHeadBlock and collectLogs
7. NewPayload / report statistics: skip report snapshot/pathdb size if in minerMode
```
