### PR TITLE
rename pevm option

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -170,7 +170,7 @@ var (
 		utils.RollupHaltOnIncompatibleProtocolVersionFlag,
 		utils.RollupSuperchainUpgradesFlag,
 		utils.ParallelTxLegacyFlag,
-		utils.ParallelTx2Flag,
+		utils.ParallelTxFlag,
 		utils.ParallelTxNumFlag,
 		utils.ParallelTxDAGFlag,
 		utils.ParallelTxDAGFileFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -169,7 +169,7 @@ var (
 		utils.RollupComputePendingBlock,
 		utils.RollupHaltOnIncompatibleProtocolVersionFlag,
 		utils.RollupSuperchainUpgradesFlag,
-		utils.ParallelTxFlag,
+		utils.ParallelTxLegacyFlag,
 		utils.ParallelTx2Flag,
 		utils.ParallelTxNumFlag,
 		utils.ParallelTxDAGFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1101,7 +1101,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Category: flags.VMCategory,
 	}
 
-	ParallelTx2Flag = &cli.BoolFlag{
+	ParallelTxFlag = &cli.BoolFlag{
 		Name:     "parallel",
 		Usage:    "Enable the experimental parallel transaction execution mode, only valid in full sync mode (default = false)",
 		Category: flags.VMCategory,
@@ -2045,8 +2045,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.ParallelTxNum = parallelNum
 	}
 
-	if ctx.IsSet(ParallelTx2Flag.Name) {
-		cfg.ParallelTxMode2 = ctx.Bool(ParallelTx2Flag.Name)
+	if ctx.IsSet(ParallelTxFlag.Name) {
+		cfg.ParallelTxMode = ctx.Bool(ParallelTxFlag.Name)
 	}
 
 	if ctx.IsSet(ParallelTxDAGFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1095,14 +1095,14 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Category: flags.MetricsCategory,
 	}
 
-	ParallelTxFlag = &cli.BoolFlag{
-		Name:     "parallel",
+	ParallelTxLegacyFlag = &cli.BoolFlag{
+		Name:     "parallel_legacy",
 		Usage:    "Enable the experimental parallel transaction execution mode, only valid in full sync mode (default = false)",
 		Category: flags.VMCategory,
 	}
 
 	ParallelTx2Flag = &cli.BoolFlag{
-		Name:     "parallel2",
+		Name:     "parallel",
 		Usage:    "Enable the experimental parallel transaction execution mode, only valid in full sync mode (default = false)",
 		Category: flags.VMCategory,
 	}
@@ -2023,8 +2023,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.EnablePreimageRecording = ctx.Bool(VMEnableDebugFlag.Name)
 	}
 
-	if ctx.IsSet(ParallelTxFlag.Name) {
-		cfg.ParallelTxMode = ctx.Bool(ParallelTxFlag.Name)
+	if ctx.IsSet(ParallelTxLegacyFlag.Name) {
+		cfg.ParallelTxLegacyMode = ctx.Bool(ParallelTxLegacyFlag.Name)
 		// The best parallel num will be tuned later, we do a simple parallel num set here
 		numCpu := runtime.NumCPU()
 		var parallelNum int

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1096,7 +1096,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 	}
 
 	ParallelTxLegacyFlag = &cli.BoolFlag{
-		Name:     "parallel_legacy",
+		Name:     "parallel-legacy",
 		Usage:    "Enable the experimental parallel transaction execution mode, only valid in full sync mode (default = false)",
 		Category: flags.VMCategory,
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -531,7 +531,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		bc.snaps, _ = snapshot.New(snapconfig, bc.db, bc.triedb, head.Root)
 	}
 
-	if bc.vmConfig.EnableParallelExec {
+	if bc.vmConfig.EnableParallelExecLegacy {
 		bc.CreateParallelProcessor(bc.vmConfig.ParallelTxNum)
 		bc.CreateSerialProcessor(chainConfig, bc, engine)
 	} else if bc.vmConfig.EnableParallelExecV2 {
@@ -1909,7 +1909,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			statedb.StartPrefetcher("chain")
 			activeState = statedb
 
-			if bc.vmConfig.EnableParallelExec {
+			if bc.vmConfig.EnableParallelExecLegacy {
 				bc.parseTxDAG(block)
 				txsCount := block.Transactions().Len()
 				threshold := min(bc.vmConfig.ParallelTxNum/2+2, 4)
@@ -1971,7 +1971,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		vtime := time.Since(vstart)
 		proctime := time.Since(start) // processing + validation
 
-		if bc.enableTxDAG && !bc.vmConfig.EnableParallelExec && !bc.vmConfig.EnableParallelExecV2 {
+		if bc.enableTxDAG && !bc.vmConfig.EnableParallelExecLegacy && !bc.vmConfig.EnableParallelExecV2 {
 			// compare input TxDAG when it enable in consensus
 			dag, err := statedb.ResolveTxDAG(len(block.Transactions()), []common.Address{block.Coinbase(), params.OptimismBaseFeeRecipient, params.OptimismL1FeeRecipient})
 			if err == nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -534,8 +534,10 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if bc.vmConfig.EnableParallelExecLegacy {
 		bc.CreateParallelProcessor(bc.vmConfig.ParallelTxNum)
 		bc.CreateSerialProcessor(chainConfig, bc, engine)
+		log.Info("Parallel V1 enabled", "parallelNum", bc.vmConfig.ParallelTxNum)
 	} else if bc.vmConfig.EnableParallelExec {
 		bc.processor = newPEVMProcessor(chainConfig, bc, engine)
+		log.Info("Parallel V2 enabled", "parallelNum", ParallelNum())
 	} else {
 		bc.processor = NewStateProcessor(chainConfig, bc, engine)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -534,7 +534,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 	if bc.vmConfig.EnableParallelExecLegacy {
 		bc.CreateParallelProcessor(bc.vmConfig.ParallelTxNum)
 		bc.CreateSerialProcessor(chainConfig, bc, engine)
-	} else if bc.vmConfig.EnableParallelExecV2 {
+	} else if bc.vmConfig.EnableParallelExec {
 		bc.processor = newPEVMProcessor(chainConfig, bc, engine)
 	} else {
 		bc.processor = NewStateProcessor(chainConfig, bc, engine)
@@ -1923,7 +1923,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 				}
 			}
 
-			if bc.vmConfig.EnableParallelExecV2 {
+			if bc.vmConfig.EnableParallelExec {
 				bc.parseTxDAG(block)
 			}
 			// If we have a followup block, run that against the current state to pre-cache
@@ -1971,7 +1971,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 		vtime := time.Since(vstart)
 		proctime := time.Since(start) // processing + validation
 
-		if bc.enableTxDAG && !bc.vmConfig.EnableParallelExecLegacy && !bc.vmConfig.EnableParallelExecV2 {
+		if bc.enableTxDAG && !bc.vmConfig.EnableParallelExecLegacy && !bc.vmConfig.EnableParallelExec {
 			// compare input TxDAG when it enable in consensus
 			dag, err := statedb.ResolveTxDAG(len(block.Transactions()), []common.Address{block.Coinbase(), params.OptimismBaseFeeRecipient, params.OptimismL1FeeRecipient})
 			if err == nil {

--- a/core/parallel_state_scheduler.go
+++ b/core/parallel_state_scheduler.go
@@ -12,8 +12,9 @@ import (
 var runner chan func()
 
 func init() {
-	runner = make(chan func(), runtime.NumCPU())
-	for i := 0; i < runtime.NumCPU(); i++ {
+	cpuNum := runtime.NumCPU()
+	runner = make(chan func(), cpuNum)
+	for i := 0; i < cpuNum; i++ {
 		go func() {
 			for f := range runner {
 				f()

--- a/core/pevm_processor_test.go
+++ b/core/pevm_processor_test.go
@@ -142,7 +142,7 @@ func loadGenesis(jsonfile string) *Genesis {
 func buildBlockChain(genesis *Genesis, parallel bool) *BlockChain {
 	archiveDb := rawdb.NewMemoryDatabase()
 	// Import the chain as an archive node for the comparison baseline
-	archive, err := NewBlockChain(archiveDb, DefaultCacheConfigWithScheme(rawdb.PathScheme), genesis, nil, ethash.NewFaker(), vm.Config{EnableParallelExecV2: parallel}, nil, nil)
+	archive, err := NewBlockChain(archiveDb, DefaultCacheConfigWithScheme(rawdb.PathScheme), genesis, nil, ethash.NewFaker(), vm.Config{EnableParallelExec: parallel}, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -197,7 +197,7 @@ func BenchmarkAkaka(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		archiveDb := rawdb.NewMemoryDatabase()
 		// Import the chain as an archive node for the comparison baseline
-		archive, _ := NewBlockChain(archiveDb, DefaultCacheConfigWithScheme(rawdb.PathScheme), gspec, nil, ethash.NewFaker(), vm.Config{EnableParallelExecV2: true}, nil, nil)
+		archive, _ := NewBlockChain(archiveDb, DefaultCacheConfigWithScheme(rawdb.PathScheme), gspec, nil, ethash.NewFaker(), vm.Config{EnableParallelExec: true}, nil, nil)
 		if n, err := archive.InsertChain(blocks); err != nil {
 			panic(fmt.Sprintf("failed to process block %d: %v", n, err))
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -98,7 +98,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
 	statedb.MarkFullProcessed()
-	if p.bc.enableTxDAG && !p.bc.vmConfig.EnableParallelExecLegacy && !p.bc.vmConfig.EnableParallelExecV2 {
+	if p.bc.enableTxDAG && !p.bc.vmConfig.EnableParallelExecLegacy && !p.bc.vmConfig.EnableParallelExec {
 		statedb.ResetMVStates(len(block.Transactions()))
 	}
 	// Iterate over and process the individual transactions

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -98,7 +98,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
 	statedb.MarkFullProcessed()
-	if p.bc.enableTxDAG && !p.bc.vmConfig.EnableParallelExec && !p.bc.vmConfig.EnableParallelExecV2 {
+	if p.bc.enableTxDAG && !p.bc.vmConfig.EnableParallelExecLegacy && !p.bc.vmConfig.EnableParallelExecV2 {
 		statedb.ResetMVStates(len(block.Transactions()))
 	}
 	// Iterate over and process the individual transactions

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -34,7 +34,7 @@ type Config struct {
 	NoBaseFee                   bool                // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
 	EnablePreimageRecording     bool                // Enables recording of SHA3/keccak preimages
 	ExtraEips                   []int               // Additional EIPS that are to be enabled
-	EnableParallelExec          bool                // Whether to execute transaction in parallel mode when do full sync
+	EnableParallelExecLegacy    bool                // Whether to execute transaction in parallel mode when do full sync
 	EnableParallelExecV2        bool                // Whether to execute transaction in parallel mode when do full sync
 	ParallelTxNum               int                 // Number of slot for transaction execution
 	OptimismPrecompileOverrides PrecompileOverrides // Precompile overrides for Optimism

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -35,7 +35,7 @@ type Config struct {
 	EnablePreimageRecording     bool                // Enables recording of SHA3/keccak preimages
 	ExtraEips                   []int               // Additional EIPS that are to be enabled
 	EnableParallelExecLegacy    bool                // Whether to execute transaction in parallel mode when do full sync
-	EnableParallelExecV2        bool                // Whether to execute transaction in parallel mode when do full sync
+	EnableParallelExec          bool                // Whether to execute transaction in parallel mode when do full sync
 	ParallelTxNum               int                 // Number of slot for transaction execution
 	OptimismPrecompileOverrides PrecompileOverrides // Precompile overrides for Optimism
 	EnableOpcodeOptimizations   bool                // Enable opcode optimization

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -224,7 +224,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	var (
 		vmConfig = vm.Config{
 			EnablePreimageRecording:   config.EnablePreimageRecording,
-			EnableParallelExec:        config.ParallelTxMode,
+			EnableParallelExecLegacy:  config.ParallelTxLegacyMode,
 			EnableParallelExecV2:      config.ParallelTxMode2,
 			ParallelTxNum:             config.ParallelTxNum,
 			EnableOpcodeOptimizations: config.EnableOpcodeOptimizing,
@@ -278,7 +278,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		if config.ParallelTxMode2 {
 			eth.blockchain.SetupTxDAGGeneration(config.ParallelTxDAGFile, config.ParallelTxMode2)
 		} else {
-			eth.blockchain.SetupTxDAGGeneration(config.ParallelTxDAGFile, config.ParallelTxMode)
+			eth.blockchain.SetupTxDAGGeneration(config.ParallelTxDAGFile, config.ParallelTxLegacyMode)
 		}
 	}
 	if chainConfig := eth.blockchain.Config(); chainConfig.Optimism != nil { // config.Genesis.Config.ChainID cannot be used because it's based on CLI flags only, thus default to mainnet L1

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -225,7 +225,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		vmConfig = vm.Config{
 			EnablePreimageRecording:   config.EnablePreimageRecording,
 			EnableParallelExecLegacy:  config.ParallelTxLegacyMode,
-			EnableParallelExecV2:      config.ParallelTxMode2,
+			EnableParallelExec:        config.ParallelTxMode,
 			ParallelTxNum:             config.ParallelTxNum,
 			EnableOpcodeOptimizations: config.EnableOpcodeOptimizing,
 		}
@@ -275,8 +275,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, err
 	}
 	if config.EnableParallelTxDAG {
-		if config.ParallelTxMode2 {
-			eth.blockchain.SetupTxDAGGeneration(config.ParallelTxDAGFile, config.ParallelTxMode2)
+		if config.ParallelTxMode {
+			eth.blockchain.SetupTxDAGGeneration(config.ParallelTxDAGFile, config.ParallelTxMode)
 		} else {
 			eth.blockchain.SetupTxDAGGeneration(config.ParallelTxDAGFile, config.ParallelTxLegacyMode)
 		}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -219,7 +219,7 @@ type Config struct {
 	RollupDisableTxPoolAdmission            bool
 	RollupHaltOnIncompatibleProtocolVersion string
 
-	ParallelTxMode         bool // Whether to execute transaction in parallel mode when do full sync
+	ParallelTxLegacyMode   bool // Whether to execute transaction in parallel mode when do full sync
 	ParallelTxMode2        bool // Whether to execute transaction in parallel mode when do full sync
 	ParallelTxNum          int  // Number of slot for transaction execution
 	EnableOpcodeOptimizing bool

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -220,7 +220,7 @@ type Config struct {
 	RollupHaltOnIncompatibleProtocolVersion string
 
 	ParallelTxLegacyMode   bool // Whether to execute transaction in parallel mode when do full sync
-	ParallelTxMode2        bool // Whether to execute transaction in parallel mode when do full sync
+	ParallelTxMode         bool // Whether to execute transaction in parallel mode when do full sync
 	ParallelTxNum          int  // Number of slot for transaction execution
 	EnableOpcodeOptimizing bool
 	EnableParallelTxDAG    bool

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -151,9 +151,9 @@ func (t *BlockTest) Run(snapshotter bool, scheme string, tracer vm.EVMLogger, po
 		cache.SnapshotWait = true
 	}
 	chain, err := core.NewBlockChain(db, cache, gspec, nil, engine, vm.Config{
-		EnableParallelExec: enableParallel,
-		ParallelTxNum:      4,
-		Tracer:             tracer,
+		EnableParallelExecV2: enableParallel,
+		ParallelTxNum:        4,
+		Tracer:               tracer,
 	}, nil, nil)
 	if err != nil {
 		return err

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -151,9 +151,9 @@ func (t *BlockTest) Run(snapshotter bool, scheme string, tracer vm.EVMLogger, po
 		cache.SnapshotWait = true
 	}
 	chain, err := core.NewBlockChain(db, cache, gspec, nil, engine, vm.Config{
-		EnableParallelExecV2: enableParallel,
-		ParallelTxNum:        4,
-		Tracer:               tracer,
+		EnableParallelExec: enableParallel,
+		ParallelTxNum:      4,
+		Tracer:             tracer,
 	}, nil, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
do some args optimizations:
1. '--parallel2' is remove.
2. '--parallel'  will be used instead of '--parallel2'.
3. '--parallel-legacy' is added for the old version of pevm.
4. add log info when enabling parallel evm.