### PR TITLE
pevm: If TxDAG is nil, then use the serial processor to handle it.

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -317,7 +317,6 @@ type BlockChain struct {
 	txDAGWriteCh      chan TxDAGOutputItem
 	txDAGReader       *TxDAGFileReader
 	serialProcessor   Processor
-	parallelProcessor Processor
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -537,6 +536,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 
 	if bc.vmConfig.EnableParallelExec {
 		bc.processor = newPEVMProcessor(chainConfig, bc, engine)
+		bc.serialProcessor = NewStateProcessor(chainConfig, bc, engine)
 		log.Info("Parallel V2 enabled", "parallelNum", ParallelNum())
 	} else {
 		bc.processor = NewStateProcessor(chainConfig, bc, engine)
@@ -1936,7 +1936,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 
 			// Process block using the parent state as reference point
 			pstart = time.Now()
-			receipts, logs, usedGas, err = bc.processor.Process(block, statedb, bc.vmConfig)
+			if bc.vmConfig.TxDAG == nil && bc.vmConfig.EnableParallelUnorderedMerge {
+				receipts, logs, usedGas, err = bc.serialProcessor.Process(block, statedb, bc.vmConfig)
+			} else {
+				receipts, logs, usedGas, err = bc.processor.Process(block, statedb, bc.vmConfig)
+			}
 			if err != nil {
 				bc.reportBlock(block, receipts, err)
 				followupInterrupt.Store(true)

--- a/core/state/pevm_statedb.go
+++ b/core/state/pevm_statedb.go
@@ -486,9 +486,6 @@ func (pst *UncommittedDB) Merge(deleteEmptyObjects bool) error {
 		// so we don't need to merge anything.
 		return nil
 	}
-	//if err := pst.conflictsToMaindb(); err != nil {
-	//	return err
-	//}
 
 	// 0. set the TxContext
 	pst.maindb.SetTxContext(pst.txHash, pst.txIndex)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -54,14 +54,6 @@ func NewStateProcessor(config *params.ChainConfig, bc *BlockChain, engine consen
 	}
 }
 
-// CreateSerialProcessor create a new StateProcessor
-func (bc *BlockChain) CreateSerialProcessor(config *params.ChainConfig, bc2 *BlockChain, engine consensus.Engine) {
-	if bc.serialProcessor == nil {
-		bc.serialProcessor = NewStateProcessor(config, bc2, engine)
-		bc.parallelExecution = false
-	}
-}
-
 // Process processes the state changes according to the Ethereum rules by running
 // the transaction messages using the statedb and applying any rewards to both
 // the processor (coinbase) and any included uncles.


### PR DESCRIPTION
### Description

If TxDAG is nil, then use the serial processor to handle it.

### Rationale

The current version of TxDAG reads from a file, so it may not be able to read after a certain block height, and a serial processor should be used to execute it.

