### PR TITLE
fix(op-geth): add new field in SimulateGaslessBundleResp

### DIFF
--- a/core/types/bundle_gasless.go
+++ b/core/types/bundle_gasless.go
@@ -15,6 +15,7 @@ type GaslessTxSimResult struct {
 }
 
 type SimulateGaslessBundleResp struct {
-	ValidResults     []GaslessTxSimResult
-	BasedBlockNumber int64
+	ValidResults      []GaslessTxSimResult
+	GasReachedResults []GaslessTxSimResult
+	BasedBlockNumber  int64
 }


### PR DESCRIPTION
### Description

Add new field in SimulateGaslessBundleResp.

### Rationale

In high-traffic scenarios, simulategaslessbundle will reach the gaslimit and cause an error. A new field needs to be added to identify it.

### Example

N/A.

### Changes

Notable changes:
* Add new field in SimulateGaslessBundleResp.
