### PR TITLE
fix ut case of TestBlockchainWithTxDAGDebug

### DIFF
--- a/core/parallel_state_scheduler.go
+++ b/core/parallel_state_scheduler.go
@@ -30,6 +30,10 @@ func initParallelRunner(targetNum int) {
 	})
 }
 
+func InitPevmRunner(targetNum int) {
+	initParallelRunner(targetNum)
+}
+
 func ParallelNum() int {
 	return cap(runner)
 }

--- a/tests/block_test.go
+++ b/tests/block_test.go
@@ -18,14 +18,16 @@ package tests
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sync/atomic"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 )
 
 func TestBlockchainWithTxDAG(t *testing.T) {
@@ -130,6 +132,7 @@ func execBlockTestWithTxDAG(t *testing.T, bt *testMatcher, test *BlockTest) {
 	}
 
 	// run again with dagFile
+	core.InitPevmRunner(1)
 	if err := bt.checkFailure(t, test.Run(true, rawdb.PathScheme, nil, nil, txDAGFile, true)); err != nil {
 		t.Errorf("test in path mode with snapshotter failed: %v", err)
 		return


### PR DESCRIPTION
### Description

The ut TestBlockchainWithTxDAGDebug failed and report two errors:
1.  invalid gas used:
```
        --- FAIL: TestBlockchainWithTxDAG/InvalidBlocks/bcStateTests/transactionFromSelfDestructedContract.json/transactionFromSelfDestructedContract_London (0.00s)
            block_test.go:134: test in path mode with snapshotter failed: block #1 insertion into chain failed: invalid gas used (remote: 95603 local: 70603)
        --- FAIL: TestBlockchainWithTxDAG/InvalidBlocks/bcStateTests/transactionFromSelfDestructedContract.json/transactionFromSelfDestructedContract_Merge (0.00s)
            block_test.go:134: test in path mode with snapshotter failed: block #1 insertion into chain failed: invalid gas used (remote: 95603 local: 70603)
        --- FAIL: TestBlockchainWithTxDAG/InvalidBlocks/bcStateTests/transactionFromSelfDestructedContract.json/transactionFromSelfDestructedContract_Shanghai (0.01s)
            block_test.go:134: test in path mode with snapshotter failed: block #1 insertion into chain failed: invalid gas used (remote: 95603 local: 70603)
```

2. invalid mercle root:
```
            block_test.go:134: test in path mode with snapshotter failed: block #2 insertion into chain failed: invalid merkle root (remote: 602b01d9587fd41105414b9cb65d20918836a971e664fd8184b1cc99fce6b618 local: c76d6f3b4866e53c0bc66eb62890efff73b99196a34c235bb29b3771f98e98da) dberr: %!w(<nil>)
```

### cause of `invalid gas used`
UncommittedDB forgets to load the code of an object before checking whether it is empty or not, which makes the method  Empty() possiblely return false.

### cause of `invalid mercle root`
(Unknown, to be continued)