### PR TITLE
pevm: fix the blockNumber used by txDAGReader during initialization

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2749,7 +2749,7 @@ func (bc *BlockChain) SetupTxDAGGeneration(output string, readFile bool) {
 			log.Error("read TxDAG err", "err", err)
 		}
 		// startup with latest block
-		curHeader := bc.CurrentHeader()
+		curHeader := bc.CurrentBlock()
 		if curHeader != nil && bc.txDAGReader != nil {
 			err := bc.txDAGReader.InitAndStartReadingLock(curHeader.Number.Uint64())
 			if err != nil {


### PR DESCRIPTION
### Description

Use bc.CurrentBlock() instead of bc.CurrentHeader() when initializing txDAGReader.

### Rationale

When a block rollback occurs, using bc.CurrentBlock() is the way to get the correct starting block height.

### Example

none


