### PR TITLE
PEVM-fix: Disable prefetch when PEVM enabled

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -312,11 +312,10 @@ type BlockChain struct {
 	forker     *ForkChoice
 	vmConfig   vm.Config
 
-	parallelExecution bool
-	enableTxDAG       bool
-	txDAGWriteCh      chan TxDAGOutputItem
-	txDAGReader       *TxDAGFileReader
-	serialProcessor   Processor
+	enableTxDAG     bool
+	txDAGWriteCh    chan TxDAGOutputItem
+	txDAGReader     *TxDAGFileReader
+	serialProcessor Processor
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -1920,7 +1919,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			// If we have a followup block, run that against the current state to pre-cache
 			// transactions and probabilistically some of the account/storage trie nodes.
 			// parallel mode has a pipeline, similar to this prefetch, to save CPU we disable this prefetch for parallel
-			if !bc.cacheConfig.TrieCleanNoPrefetch && !bc.parallelExecution {
+			if !bc.cacheConfig.TrieCleanNoPrefetch && !bc.vmConfig.EnableParallelExec {
 				if followup, err := it.peek(); followup != nil && err == nil {
 					throwaway, _ := state.New(parent.Root, bc.stateCache, bc.snaps)
 


### PR DESCRIPTION
There is no necessary to do prefetch for PEVM.

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...
