### PR TITLE
fix(op-geth): fix gasless receipt l1fee

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -587,7 +587,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			rs[i].L1GasPrice = gasParams.l1BaseFee
 			rs[i].L1BlobBaseFee = gasParams.l1BlobBaseFee
 			rs[i].L1Fee, rs[i].L1GasUsed = gasParams.costFunc(txs[i].RollupCostData())
-			if txs[i].inner.effectiveGasPrice(new(big.Int), baseFee).Cmp(big.NewInt(0)) == 0 && config.IsWright(time) {
+			if rs[i].EffectiveGasPrice.Cmp(big.NewInt(0)) == 0 && config.IsWright(time) {
 				rs[i].L1Fee = big.NewInt(0)
 			}
 			rs[i].FeeScalar = gasParams.feeScalar

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -587,7 +587,7 @@ func (rs Receipts) DeriveFields(config *params.ChainConfig, hash common.Hash, nu
 			rs[i].L1GasPrice = gasParams.l1BaseFee
 			rs[i].L1BlobBaseFee = gasParams.l1BlobBaseFee
 			rs[i].L1Fee, rs[i].L1GasUsed = gasParams.costFunc(txs[i].RollupCostData())
-			if txs[i].GasPrice().Cmp(big.NewInt(0)) == 0 && config.IsWright(time) {
+			if txs[i].inner.effectiveGasPrice(new(big.Int), baseFee).Cmp(big.NewInt(0)) == 0 && config.IsWright(time) {
 				rs[i].L1Fee = big.NewInt(0)
 			}
 			rs[i].FeeScalar = gasParams.feeScalar


### PR DESCRIPTION
### Description

Fix gasless tx receipt l1 fee result.

### Rationale

When TipFeeCap is 0 and GasFeeCap is not, the effective gas price is 0, opBNB not charge L1 fee, but the result of tx receipt  
shows that l1fee is charged. 

### Example

https://testnet.opbnbscan.com/tx/0xf54b5aa2960baaed2d426c97f947ce79e39fd575047f55d2de9d8f8732833a63

### Changes

Notable changes:
* Fix gasless tx receipt l1 fee result, when effective gas price is 0, the l1 fee is 0.
