### PR TITLE
fix: fix StateScheme overwrite bug

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -163,12 +163,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	scheme, err := rawdb.ParseStateScheme(config.StateScheme, chainDb)
+	config.StateScheme, err = rawdb.ParseStateScheme(config.StateScheme, chainDb)
 	if err != nil {
 		return nil, err
 	}
 	// Try to recover offline state pruning only in hash-based.
-	if scheme == rawdb.HashScheme {
+	if config.StateScheme == rawdb.HashScheme {
 		if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb); err != nil {
 			log.Error("Failed to recover state", "error", err)
 		}


### PR DESCRIPTION
### Description

In PR #127, while resolving merge conflicts, the return value of ParseStateScheme was unintentionally altered. This change caused the config.StateScheme variable to be consistently set to nil when passed to pbss, leading to issues in downstream operations.

### Rationale

Restored the correct return value in ParseStateScheme to ensure that config.StateScheme is properly assigned and passed to pbss, restoring intended functionality.

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...
