### PR TITLE
fix: recover node buffer list trie nodes for graceful kill

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -195,6 +195,7 @@ func (c *CacheConfig) triedbConfig(keepFunc pathdb.NotifyKeepFunc) *triedb.Confi
 			NotifyKeep:           keepFunc,
 			JournalFilePath:      c.JournalFilePath,
 			JournalFile:          c.JournalFile,
+			UseBase:              c.UseBase,
 		}
 	}
 	return config

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -217,6 +217,7 @@ var defaultCacheConfig = &CacheConfig{
 func DefaultCacheConfigWithScheme(scheme string) *CacheConfig {
 	config := *defaultCacheConfig
 	config.StateScheme = scheme
+	config.UseBase = true
 	return &config
 }
 

--- a/core/blockchain_snapshot_test.go
+++ b/core/blockchain_snapshot_test.go
@@ -81,7 +81,9 @@ func (basic *snapshotTestBasic) prepare(t *testing.T) (*BlockChain, []*types.Blo
 		}
 		engine = ethash.NewFullFaker()
 	)
-	chain, err := NewBlockChain(db, DefaultCacheConfigWithScheme(basic.scheme), gspec, nil, engine, vm.Config{}, nil, nil)
+	cacheConfig := DefaultCacheConfigWithScheme(basic.scheme)
+	cacheConfig.UseBase = true
+	chain, err := NewBlockChain(db, cacheConfig, gspec, nil, engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to create chain: %v", err)
 	}
@@ -180,11 +182,11 @@ func (basic *snapshotTestBasic) dump() string {
 	}
 	fmt.Fprint(buffer, "\n")
 
-	//if crash {
+	// if crash {
 	//	fmt.Fprintf(buffer, "\nCRASH\n\n")
-	//} else {
+	// } else {
 	//	fmt.Fprintf(buffer, "\nSetHead(%d)\n\n", basic.setHead)
-	//}
+	// }
 	fmt.Fprintf(buffer, "------------------------------\n\n")
 
 	fmt.Fprint(buffer, "Expected in leveldb:\n  G")
@@ -228,7 +230,10 @@ func (snaptest *snapshotTest) test(t *testing.T) {
 
 	// Restart the chain normally
 	chain.Stop()
-	newchain, err := NewBlockChain(snaptest.db, DefaultCacheConfigWithScheme(snaptest.scheme), snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
+
+	cacheConfig := DefaultCacheConfigWithScheme(snaptest.scheme)
+	cacheConfig.UseBase = true
+	newchain, err := NewBlockChain(snaptest.db, cacheConfig, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
 	}
@@ -313,6 +318,7 @@ func (snaptest *gappedSnapshotTest) test(t *testing.T) {
 		SnapshotLimit:  0,
 		StateScheme:    snaptest.scheme,
 	}
+	cacheConfig.UseBase = true
 	newchain, err := NewBlockChain(snaptest.db, cacheConfig, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
@@ -321,7 +327,9 @@ func (snaptest *gappedSnapshotTest) test(t *testing.T) {
 	newchain.Stop()
 
 	// Restart the chain with enabling the snapshot
-	newchain, err = NewBlockChain(snaptest.db, DefaultCacheConfigWithScheme(snaptest.scheme), snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
+	config := DefaultCacheConfigWithScheme(snaptest.scheme)
+	config.UseBase = true
+	newchain, err = NewBlockChain(snaptest.db, config, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
 	}
@@ -349,7 +357,9 @@ func (snaptest *setHeadSnapshotTest) test(t *testing.T) {
 	chain.SetHead(snaptest.setHead)
 	chain.Stop()
 
-	newchain, err := NewBlockChain(snaptest.db, DefaultCacheConfigWithScheme(snaptest.scheme), snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
+	cacheConfig := DefaultCacheConfigWithScheme(snaptest.scheme)
+	cacheConfig.UseBase = true
+	newchain, err := NewBlockChain(snaptest.db, cacheConfig, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
 	}
@@ -385,6 +395,7 @@ func (snaptest *wipeCrashSnapshotTest) test(t *testing.T) {
 		SnapshotLimit:  0,
 		StateScheme:    snaptest.scheme,
 	}
+	config.UseBase = true
 	newchain, err := NewBlockChain(snaptest.db, config, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
@@ -402,6 +413,7 @@ func (snaptest *wipeCrashSnapshotTest) test(t *testing.T) {
 		SnapshotWait:   false, // Don't wait rebuild
 		StateScheme:    snaptest.scheme,
 	}
+	config.UseBase = true
 	tmp, err := NewBlockChain(snaptest.db, config, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
@@ -411,7 +423,9 @@ func (snaptest *wipeCrashSnapshotTest) test(t *testing.T) {
 	tmp.triedb.Close()
 	tmp.stopWithoutSaving()
 
-	newchain, err = NewBlockChain(snaptest.db, DefaultCacheConfigWithScheme(snaptest.scheme), snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
+	cacheConfig := DefaultCacheConfigWithScheme(snaptest.scheme)
+	cacheConfig.UseBase = true
+	newchain, err = NewBlockChain(snaptest.db, cacheConfig, snaptest.gspec, nil, snaptest.engine, vm.Config{}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)
 	}

--- a/core/rawdb/freezer.go
+++ b/core/rawdb/freezer.go
@@ -127,7 +127,7 @@ func NewFreezer(datadir string, namespace string, readonly, writeTrieNode bool, 
 	// Create the tables.
 	for name, disableSnappy := range tables {
 		if name == stateHistoryTrieNodesData && !writeTrieNode {
-			log.Info("Not create trie node data")
+			log.Info("Not create trie node data in freezer db")
 			continue
 		}
 		table, err := newTable(datadir, name, readMeter, writeMeter, sizeGauge, maxTableSize, disableSnappy, readonly)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/txpool/blobpool"
-	"github.com/ethereum/go-ethereum/core/txpool/bundlepool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state/pruner"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/txpool/blobpool"
+	"github.com/ethereum/go-ethereum/core/txpool/bundlepool"
 	"github.com/ethereum/go-ethereum/core/txpool/legacypool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -134,6 +135,17 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.Miner.GasPrice = new(big.Int).Set(ethconfig.Defaults.Miner.GasPrice)
 	}
 
+	// Assemble the Ethereum object
+	chainDb, err := stack.OpenAndMergeDatabase("chaindata", ChainDBNamespace, false, config.DatabaseCache, config.DatabaseHandles,
+		config.DatabaseFreezer)
+	if err != nil {
+		return nil, err
+	}
+	config.StateScheme, err = rawdb.ParseStateScheme(config.StateScheme, chainDb)
+	if err != nil {
+		return nil, err
+	}
+
 	if config.StateScheme == rawdb.HashScheme && config.NoPruning && config.TrieDirtyCache > 0 {
 		if config.SnapshotCache > 0 {
 			config.TrieCleanCache += config.TrieDirtyCache * 3 / 5
@@ -153,21 +165,11 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		config.TrieCleanCache += config.TrieDirtyCache - pathdb.MaxBufferSize/1024/1024
 		config.TrieDirtyCache = pathdb.MaxBufferSize / 1024 / 1024
 	}
-	log.Info("Allocated memory caches",
-		"state_scheme", config.StateScheme,
+	log.Info("Allocated memory caches", "state_scheme", config.StateScheme,
 		"trie_clean_cache", common.StorageSize(config.TrieCleanCache)*1024*1024,
 		"trie_dirty_cache", common.StorageSize(config.TrieDirtyCache)*1024*1024,
 		"snapshot_cache", common.StorageSize(config.SnapshotCache)*1024*1024)
-	// Assemble the Ethereum object
-	chainDb, err := stack.OpenAndMergeDatabase("chaindata", ChainDBNamespace, false, config.DatabaseCache, config.DatabaseHandles,
-		config.DatabaseFreezer)
-	if err != nil {
-		return nil, err
-	}
-	config.StateScheme, err = rawdb.ParseStateScheme(config.StateScheme, chainDb)
-	if err != nil {
-		return nil, err
-	}
+
 	// Try to recover offline state pruning only in hash-based.
 	if config.StateScheme == rawdb.HashScheme {
 		if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb); err != nil {

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -180,6 +180,7 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 		diskdb:     diskdb,
 		useBase:    config.UseBase,
 	}
+	fmt.Println("useBase", db.useBase)
 
 	// Open the freezer for state history if the passed database contains an
 	// ancient store. Otherwise, all the relevant functionalities are disabled.

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -180,7 +180,6 @@ func New(diskdb ethdb.Database, config *Config) *Database {
 		diskdb:     diskdb,
 		useBase:    config.UseBase,
 	}
-	fmt.Println("useBase", db.useBase)
 
 	// Open the freezer for state history if the passed database contains an
 	// ancient store. Otherwise, all the relevant functionalities are disabled.
@@ -369,7 +368,7 @@ func (db *Database) Enable(root common.Hash) error {
 	// Re-construct a new disk layer backed by persistent state
 	// with **empty clean cache and node buffer**.
 	nb, err := NewTrieNodeBuffer(db.diskdb, db.config.TrieNodeBufferType, db.bufferSize, nil, 0, db.config.ProposeBlockInterval,
-		db.config.NotifyKeep, nil, false, false)
+		db.config.NotifyKeep, db.freezer, false, false)
 	if err != nil {
 		log.Error("Failed to new trie node buffer", "error", err)
 		return err

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -319,6 +319,7 @@ func (t *tester) verifyState(root common.Hash) error {
 	}
 	_, err = reader.Node(common.Hash{}, nil, root)
 	if err != nil {
+		fmt.Println("error: ", err)
 		return errors.New("root node is not available")
 	}
 	for addrHash, account := range t.snapAccounts[root] {
@@ -459,6 +460,7 @@ func TestDisable(t *testing.T) {
 		t.Fatalf("Invalid activation should be rejected")
 	}
 	if err := tester.db.Enable(stored); err != nil {
+		fmt.Println(err)
 		t.Fatal("Failed to activate database")
 	}
 
@@ -516,7 +518,6 @@ func TestJournal(t *testing.T) {
 	}
 	tester.db.Close()
 	pathConfig := Defaults
-	pathConfig.UseBase = true
 	tester.db = New(tester.db.diskdb, pathConfig)
 
 	// Verify states including disk layer and all diff on top.

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -319,7 +319,6 @@ func (t *tester) verifyState(root common.Hash) error {
 	}
 	_, err = reader.Node(common.Hash{}, nil, root)
 	if err != nil {
-		fmt.Println("error: ", err)
 		return errors.New("root node is not available")
 	}
 	for addrHash, account := range t.snapAccounts[root] {
@@ -460,7 +459,6 @@ func TestDisable(t *testing.T) {
 		t.Fatalf("Invalid activation should be rejected")
 	}
 	if err := tester.db.Enable(stored); err != nil {
-		fmt.Println(err)
 		t.Fatal("Failed to activate database")
 	}
 

--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -516,6 +516,7 @@ func TestJournal(t *testing.T) {
 	}
 	tester.db.Close()
 	pathConfig := Defaults
+	pathConfig.UseBase = true
 	tester.db = New(tester.db.diskdb, pathConfig)
 
 	// Verify states including disk layer and all diff on top.

--- a/triedb/pathdb/journal.go
+++ b/triedb/pathdb/journal.go
@@ -255,6 +255,8 @@ func (db *Database) loadLayers() layer {
 	if err == nil {
 		return head
 	}
+	fmt.Println("load layers error: ", err)
+	log.Error("print load journal error", "error", err)
 	// journal is not matched(or missing) with the persistent state, discard
 	// it. Display log for discarding journal, but try to avoid showing
 	// useless information when the db is created from scratch.
@@ -268,12 +270,11 @@ func (db *Database) loadLayers() layer {
 		stateID = rawdb.ReadPersistentStateID(db.diskdb)
 	)
 
+	fmt.Println("use base: ", db.useBase)
 	if (errors.Is(err, errMissJournal) || errors.Is(err, errUnmatchedJournal)) && db.fastRecovery &&
 		db.config.TrieNodeBufferType == NodeBufferList && !db.useBase {
+		fmt.Println("3j3erj321")
 		start := time.Now()
-		if db.freezer == nil {
-			log.Crit("Use unopened freezer db to recover node buffer list")
-		}
 		log.Info("Recover node buffer list from ancient db")
 
 		nb, err = NewTrieNodeBuffer(db.diskdb, db.config.TrieNodeBufferType, db.bufferSize, nil, 0,
@@ -287,6 +288,7 @@ func (db *Database) loadLayers() layer {
 		}
 	}
 	if nb == nil || err != nil {
+		fmt.Println("r23k9321k9")
 		// Return single layer with persistent state.
 		nb, err = NewTrieNodeBuffer(db.diskdb, db.config.TrieNodeBufferType, db.bufferSize, nil, 0,
 			db.config.ProposeBlockInterval, db.config.NotifyKeep, nil, false, db.useBase)
@@ -365,11 +367,26 @@ func (db *Database) loadDiskLayer(r *rlp.Stream, journalTypeForReader JournalTyp
 
 	// Calculate the internal state transitions by id difference.
 	nb, err := NewTrieNodeBuffer(db.diskdb, db.config.TrieNodeBufferType, db.bufferSize, nodes, id-stored, db.config.ProposeBlockInterval,
-		db.config.NotifyKeep, nil, false, db.useBase)
+		db.config.NotifyKeep, db.freezer, db.fastRecovery, db.useBase)
 	if err != nil {
 		log.Error("Failed to new trie node buffer", "error", err)
 		return nil, err
 	}
+
+	fmt.Println("111")
+	if db.config.TrieNodeBufferType == NodeBufferList && !db.useBase {
+		fmt.Println("222")
+		recoveredRoot, recoveredStateID, _ := nb.getLatestStatus()
+		if recoveredRoot != root && recoveredStateID != id {
+			log.Error("unequal state root and state id")
+			fmt.Println("recoveredRoot, root, recoveredStateID, id", recoveredRoot, root, recoveredStateID, id)
+			return nil, errors.New("Unmatched root and state id with recovered")
+		}
+
+		log.Info("Finish recovering node buffer list", "latest root hash", recoveredRoot.String(),
+			"latest state_id", recoveredStateID)
+	}
+
 	base := newDiskLayer(root, id, db, nil, nb)
 	nb.setClean(base.cleans)
 	return base, nil

--- a/triedb/pathdb/nodebufferlist.go
+++ b/triedb/pathdb/nodebufferlist.go
@@ -224,6 +224,7 @@ func (nf *nodebufferlist) recoverNodeBufferList(freezer *rawdb.ResettableFreezer
 		nf.layers += current.layers
 	}
 	nf.diffToBase()
+	nf.backgroundFlush()
 
 	log.Info("Succeed to recover node buffer list", "base_size", nf.base.size, "tail_state_id", nf.tail.id,
 		"head_state_id", nf.head.id, "nbl_layers", nf.layers, "base_layers", nf.base.layers)

--- a/triedb/pathdb/nodebufferlist.go
+++ b/triedb/pathdb/nodebufferlist.go
@@ -108,17 +108,13 @@ func newNodeBufferList(
 		dlInMd = wpBlocks
 	}
 
-	if nodes == nil {
-		nodes = make(map[common.Hash]map[string]*trienode.Node)
-	}
-
 	nf := &nodebufferlist{
 		db:              db,
 		wpBlocks:        wpBlocks,
 		rsevMdNum:       rsevMdNum,
 		dlInMd:          dlInMd,
 		limit:           limit,
-		base:            newMultiDifflayer(limit, 0, common.Hash{}, nodes, 0),
+		base:            newMultiDifflayer(limit, 0, common.Hash{}, make(map[common.Hash]map[string]*trienode.Node), 0),
 		persistID:       rawdb.ReadPersistentStateID(db),
 		stopCh:          make(chan struct{}),
 		waitStopCh:      make(chan struct{}),
@@ -127,6 +123,7 @@ func newNodeBufferList(
 		keepFunc:        keepFunc,
 	}
 
+	fmt.Println("useBase, fastRecovery", useBase, fastRecovery)
 	if !useBase && fastRecovery {
 		if freezer == nil {
 			log.Crit("Use unopened freezer db to recover node buffer list")
@@ -164,7 +161,6 @@ func (nf *nodebufferlist) recoverNodeBufferList(freezer *rawdb.ResettableFreezer
 		log.Error("Failed to get freezer tail", "error", err)
 		return err
 	}
-	fmt.Println()
 	log.Info("Ancient db meta info", "persistent_state_id", nf.persistID, "head_state_id", head,
 		"tail_state_id", tail, "waiting_recover_num", head-nf.persistID)
 
@@ -841,8 +837,8 @@ func (nf *nodebufferlist) proposedBlockReader(blockRoot common.Hash) (layer, err
 func (nf *nodebufferlist) report() {
 	context := []interface{}{
 		"number", nf.block, "count", nf.count, "layers", nf.layers,
-		"stateid", nf.stateId, "persist", nf.persistID, "size", common.StorageSize(nf.size),
-		"basesize", common.StorageSize(nf.base.size), "baselayers", nf.base.layers,
+		"state_id", nf.stateId, "persist", nf.persistID, "size", common.StorageSize(nf.size),
+		"base_size", common.StorageSize(nf.base.size), "base_layers", nf.base.layers,
 	}
 	log.Info("node buffer list info", context...)
 }

--- a/triedb/pathdb/nodebufferlist.go
+++ b/triedb/pathdb/nodebufferlist.go
@@ -30,6 +30,9 @@ const (
 
 	// DefaultReserveMultiDifflayerNumber defines the default reserve number of multiDifflayer in nodebufferlist.
 	DefaultReserveMultiDifflayerNumber = 3
+
+	// The max batch size of pebble cannot exceed 4GB, so set maxNodeBufferListSize to 3GB.
+	maxNodeBufferListSize = 3221225472
 )
 
 type KeepRecord struct {
@@ -110,7 +113,7 @@ func newNodeBufferList(
 
 	var base *multiDifflayer
 	if nodes != nil && useBase {
-		// after using fast recovery, use ancient db to recover nbl for force kill and graceful kill.
+		// After using fast recovery, use ancient db to recover nbl for force kill and graceful kill.
 		// so this case for now is used in unit test
 		var size uint64
 		for _, subset := range nodes {
@@ -157,7 +160,7 @@ func newNodeBufferList(
 
 	go nf.loop()
 
-	log.Info("new node buffer list", "proposed block interval", nf.wpBlocks,
+	log.Info("New node buffer list", "proposed block interval", nf.wpBlocks,
 		"reserve multi diff_layers", nf.rsevMdNum, "diff_layers in multi_diff_layer", nf.dlInMd,
 		"limit", common.StorageSize(limit), "layers", layers, "persist_id", nf.persistID, "base_size", nf.size)
 	return nf, nil
@@ -194,7 +197,7 @@ func (nf *nodebufferlist) recoverNodeBufferList(freezer *rawdb.ResettableFreezer
 	if err != nil {
 		return err
 	}
-	log.Info("block intervals info", "block_intervals", blockIntervals, "state_intervals", stateIntervals,
+	log.Info("Block intervals info", "block_intervals", blockIntervals, "state_intervals", stateIntervals,
 		"start_block", startBlock, "end_block", endBlock)
 
 	var eg errgroup.Group
@@ -225,11 +228,24 @@ func (nf *nodebufferlist) recoverNodeBufferList(freezer *rawdb.ResettableFreezer
 		nf.size += current.size
 		nf.layers += current.layers
 	}
-	nf.diffToBase(true)
+
+	log.Info("Before diffToBase", "base_size", nf.base.size, "tail_state_id", nf.tail.id, "head_state_id", nf.head.id,
+		"nbl_layers", nf.layers, "base_layers", nf.base.layers, "nf_count", nf.count, "node_buffer_size", nf.size)
+
+	if nf.size >= maxNodeBufferListSize && nf.count == DefaultReserveMultiDifflayerNumber {
+		// Avoid diff size exceeding max pebble batch size limit, force flush buffer to base
+		log.Info("Node buffer list size exceeds 3GB", "node buffer size", nf.size)
+		nf.diffToBase(true)
+	} else {
+		nf.diffToBase(false)
+	}
+
+	log.Info("After diffToBase", "base_size", nf.base.size, "tail_state_id", nf.tail.id,
+		"head_state_id", nf.head.id, "nbl_layers", nf.layers, "base_layers", nf.base.layers, "nf_count", nf.count, "node_buffer_size", nf.size)
 	nf.backgroundFlush()
 
 	log.Info("Succeed to recover node buffer list", "base_size", nf.base.size, "tail_state_id", nf.tail.id,
-		"head_state_id", nf.head.id, "nbl_layers", nf.layers, "base_layers", nf.base.layers)
+		"head_state_id", nf.head.id, "nbl_layers", nf.layers, "base_layers", nf.base.layers, "nf_count", nf.count, "node_buffer_size", nf.size)
 	return nil
 }
 
@@ -679,17 +695,13 @@ func (nf *nodebufferlist) traverseReverse(cb func(*multiDifflayer) bool) {
 // base node buffer, if up to limit size and flush to disk. It is called
 // periodically in the background
 func (nf *nodebufferlist) diffToBase(skipCountCheck bool) {
-	count := 0
 	commitFunc := func(buffer *multiDifflayer) bool {
 		if nf.base.size >= nf.base.limit {
 			log.Debug("base node buffer need write disk immediately")
 			return false
 		}
-		if skipCountCheck && count == 1 { // only force flush one buffer to base
-			return false
-		}
 		if !skipCountCheck {
-			// when using fast recovery, force flush one buffer to base to avoid exceeding pebble batch size limit
+			// when using fast recovery, force flush buffer to base to avoid exceeding pebble batch size limit
 			if nf.count <= nf.rsevMdNum {
 				log.Debug("node buffer list less, waiting more difflayer to be committed")
 				return false
@@ -733,7 +745,6 @@ func (nf *nodebufferlist) diffToBase(skipCountCheck bool) {
 			baseNodeBufferDifflayerAvgSize.Update(int64(nf.base.size / nf.base.layers))
 		}
 		nf.report()
-		count++
 
 		return true
 	}


### PR DESCRIPTION
### Description

This pr aims to recover node buffer list data for graceful kill. Therefore, both graceful kill and force kill can recover data by freezerdb.

### Rationale

When using graceful kill to stop geth, the data in nodebufferlist is stored in db or journalFile. When nodebufferlist recovers data by loading all data into nodebufferlist base buffer, if the data is too large, it will exceed the pebble batch size limit and cause panic. By this pr, both graceful kill and force kill can use the same functions to recover data.

### Example

N/A

### Changes

Notable changes:
* N/A
