### PR TITLE
prepare for v0.5.3 release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.5.3
+
+This is a minor release for opBNB Mainnet and Testnet.
+
+It fixes a txpool memory leak bug that could cause out-of-memory issues.
+
+It is recommended to upgrade to this version for both Mainnet and Testnet.
+
+### What's Changed
+* fix: txpool reheap out-of-memory issues by @andyzhang2023 in https://github.com/bnb-chain/op-geth/pull/211
+
+### Docker Images
+ghcr.io/bnb-chain/op-geth:v0.5.3
+
+**Full Changelog**: https://github.com/bnb-chain/op-geth/compare/v0.5.2...v0.5.3
+
 ## v0.5.2
 
 This is a minor release for opBNB Mainnet and Testnet.

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -391,7 +391,7 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserve txpool.A
 }
 
 func (pool *LegacyPool) loopOfSync() {
-	ticker := time.NewTicker(200 * time.Millisecond)
+	ticker := time.NewTicker(400 * time.Millisecond)
 	for {
 		select {
 		case <-pool.reorgShutdownCh:
@@ -1892,6 +1892,7 @@ func (pool *LegacyPool) demoteUnexecutables(demoteAddrs []common.Address) {
 	}
 	demoteTxMeter.Mark(int64(len(demoteAddrs)))
 
+	var removed = 0
 	// Iterate over all accounts and demote any non-executable transactions
 	gasLimit := txpool.EffectiveGasLimit(pool.chainconfig, pool.currentHead.Load().GasLimit, pool.config.EffectiveGasCeil)
 	for _, addr := range demoteAddrs {
@@ -1955,7 +1956,9 @@ func (pool *LegacyPool) demoteUnexecutables(demoteAddrs []common.Address) {
 			}
 		}
 		pool.pendingCache.del(dropPendingCache, pool.signer)
+		removed += len(dropPendingCache)
 	}
+	pool.priced.Removed(removed)
 }
 
 // addressByHeartbeat is an account address tagged with its last activity timestamp.


### PR DESCRIPTION
## v0.5.3

This is a minor release for opBNB Mainnet and Testnet.

It fixes a txpool memory leak bug that could cause out-of-memory issues.

It is recommended to upgrade to this version for both Mainnet and Testnet.

### What's Changed
* fix: txpool reheap out-of-memory issues by @andyzhang2023 in https://github.com/bnb-chain/op-geth/pull/211

### Docker Images
ghcr.io/bnb-chain/op-geth:v0.5.3

**Full Changelog**: https://github.com/bnb-chain/op-geth/compare/v0.5.2...v0.5.3