### PR TITLE
pevm(txDAG): fix cannotGasFeeDelay setting bug

### DIFF
--- a/core/types/mvstates.go
+++ b/core/types/mvstates.go
@@ -987,7 +987,7 @@ func (s *MVStates) resolveDepsMapCacheByWrites(index int, reads []RWEventItem, w
 
 	for _, addr := range s.gasFeeReceivers {
 		if _, ok := addrMap[addr]; ok {
-			rwSet.cannotGasFeeDelay = true
+			s.rwSets[index].cannotGasFeeDelay = true
 			break
 		}
 	}


### PR DESCRIPTION
### Description

The `cannotGasFeeDelay` flag was not set correctly, which can cause issues with the generated txDAG.

