### PR TITLE
Txpool opt async priced

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -79,6 +79,7 @@ var (
 		utils.TxPoolRejournalFlag,
 		utils.TxPoolPriceLimitFlag,
 		utils.TxPoolPriceBumpFlag,
+		utils.TxPoolEnableAsyncPricedFlag,
 		utils.TxPoolAccountSlotsFlag,
 		utils.TxPoolGlobalSlotsFlag,
 		utils.TxPoolAccountQueueFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -410,6 +410,12 @@ var (
 		Value:    ethconfig.Defaults.TxPool.PriceBump,
 		Category: flags.TxPoolCategory,
 	}
+	TxPoolEnableAsyncPricedFlag = &cli.BoolFlag{
+		Name:     "txpool.asyncpriced",
+		Usage:    "enable async-priced-sorted list for txpool",
+		Value:    false,
+		Category: flags.TxPoolCategory,
+	}
 	TxPoolAccountSlotsFlag = &cli.Uint64Flag{
 		Name:     "txpool.accountslots",
 		Usage:    "Minimum number of executable transaction slots guaranteed per account",
@@ -1722,6 +1728,9 @@ func setTxPool(ctx *cli.Context, cfg *legacypool.Config) {
 	}
 	if ctx.IsSet(TxPoolPriceBumpFlag.Name) {
 		cfg.PriceBump = ctx.Uint64(TxPoolPriceBumpFlag.Name)
+	}
+	if ctx.IsSet(TxPoolEnableAsyncPricedFlag.Name) {
+		cfg.EnableAsyncPriced = ctx.Bool(TxPoolEnableAsyncPricedFlag.Name)
 	}
 	if ctx.IsSet(TxPoolAccountSlotsFlag.Name) {
 		cfg.AccountSlots = ctx.Uint64(TxPoolAccountSlotsFlag.Name)

--- a/core/txpool/legacypool/async_priced_list.go
+++ b/core/txpool/legacypool/async_priced_list.go
@@ -149,6 +149,8 @@ func (a *asyncPricedList) Underpriced(tx *types.Transaction) bool {
 		// be careful that fl might be nil
 		floatingLowest = fl.(*types.Transaction)
 	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	return (urgentLowest == nil || a.priced.urgent.cmp(urgentLowest, tx) >= 0) &&
 		(floatingLowest == nil || a.priced.floating.cmp(floatingLowest, tx) >= 0) &&
 		(floatingLowest != nil || urgentLowest != nil)

--- a/core/txpool/legacypool/async_priced_list.go
+++ b/core/txpool/legacypool/async_priced_list.go
@@ -1,0 +1,174 @@
+package legacypool
+
+import (
+	"math/big"
+	"sync"
+	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var _ pricedListInterface = &asyncPricedList{}
+
+type addEvent struct {
+	tx    *types.Transaction
+	local bool
+}
+
+type discardEvent struct {
+	slots int
+	force bool
+	done  chan *discardResult
+}
+type discardResult struct {
+	discardTxs types.Transactions
+	succ       bool
+}
+
+type asyncPricedList struct {
+	priced         *pricedList
+	floatingLowest atomic.Value
+	urgentLowest   atomic.Value
+	mu             sync.Mutex
+
+	// events
+	quit       chan struct{}
+	reheap     chan struct{}
+	add        chan *addEvent
+	remove     chan int
+	discard    chan *discardEvent
+	setBaseFee chan *big.Int
+}
+
+func newAsyncPricedList(all *lookup) *asyncPricedList {
+	a := &asyncPricedList{
+		priced:     newPricedList(all),
+		quit:       make(chan struct{}),
+		reheap:     make(chan struct{}),
+		add:        make(chan *addEvent),
+		remove:     make(chan int),
+		discard:    make(chan *discardEvent),
+		setBaseFee: make(chan *big.Int),
+	}
+	go a.run()
+	return a
+}
+
+// run is a loop that handles async operations:
+//   - reheap: reheap the whole priced list, to get the lowest gas price
+//   - put: add a transaction to the priced list
+//   - remove: remove transactions from the priced list
+//   - discard: remove transactions to make room for new ones
+func (a *asyncPricedList) run() {
+	var reheap bool
+	var newOnes []*types.Transaction
+	var toRemove int = 0
+	// current loop state
+	var currentDone chan struct{} = nil
+	var baseFee *big.Int = nil
+	for {
+		if currentDone == nil {
+			currentDone = make(chan struct{})
+			go func(reheap bool, newOnes []*types.Transaction, toRemove int, baseFee *big.Int) {
+				a.handle(reheap, newOnes, toRemove, baseFee, currentDone)
+				<-currentDone
+				close(currentDone)
+				currentDone = nil
+			}(reheap, newOnes, toRemove, baseFee)
+
+			reheap, newOnes, toRemove, baseFee = false, nil, 0, nil
+		}
+		select {
+		case <-a.reheap:
+			reheap = true
+
+		case add := <-a.add:
+			newOnes = append(newOnes, add.tx)
+
+		case remove := <-a.remove:
+			toRemove += remove
+
+		case baseFee = <-a.setBaseFee:
+
+		case <-a.quit:
+			return
+		}
+	}
+}
+
+func (a *asyncPricedList) handle(reheap bool, newOnes []*types.Transaction, toRemove int, baseFee *big.Int, finished chan struct{}) {
+	defer close(finished)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	// add new transactions to the priced list
+	for _, tx := range newOnes {
+		a.priced.Put(tx, false)
+	}
+	// remove staled transactions from the priced list
+	a.priced.Removed(toRemove)
+	// reheap if needed
+	if reheap {
+		a.priced.Reheap()
+		// set the lowest priced transaction when reheap is done
+		if len(a.priced.floating.list) > 0 {
+			a.floatingLowest.Store(a.priced.floating.list[0])
+		} else {
+			a.floatingLowest.Store(nil)
+		}
+		if len(a.priced.urgent.list) > 0 {
+			a.urgentLowest.Store(a.priced.urgent.list[0])
+		} else {
+			a.urgentLowest.Store(nil)
+		}
+	}
+	if baseFee != nil {
+		a.priced.SetBaseFee(baseFee)
+	}
+}
+
+func (a *asyncPricedList) Put(tx *types.Transaction, local bool) {
+	a.add <- &addEvent{tx, local}
+}
+
+func (a *asyncPricedList) Removed(count int) {
+	a.remove <- count
+}
+
+func (a *asyncPricedList) Underpriced(tx *types.Transaction) bool {
+	urgentLowest, floatingLowest := a.urgentLowest.Load(), a.floatingLowest.Load()
+	return (urgentLowest == nil || a.priced.urgent.cmp(urgentLowest.(*types.Transaction), tx) >= 0) &&
+		(floatingLowest == nil || a.priced.floating.cmp(floatingLowest.(*types.Transaction), tx) >= 0) &&
+		(floatingLowest != nil && urgentLowest != nil)
+}
+
+// Disacard cleans staled transactions to make room for new ones
+func (a *asyncPricedList) Discard(slots int, force bool) (types.Transactions, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.priced.Discard(slots, force)
+}
+
+func (a *asyncPricedList) NeedReheap(currHead *types.Header) bool {
+	return false
+}
+
+func (a *asyncPricedList) Reheap() {
+	a.reheap <- struct{}{}
+}
+
+func (a *asyncPricedList) SetBaseFee(baseFee *big.Int) {
+	a.setBaseFee <- baseFee
+	a.reheap <- struct{}{}
+}
+
+func (a *asyncPricedList) SetHead(currHead *types.Header) {
+	//do nothing
+}
+
+func (a *asyncPricedList) GetBaseFee() *big.Int {
+	return a.priced.floating.baseFee
+}
+
+func (a *asyncPricedList) Stop() {
+	close(a.quit)
+}

--- a/core/txpool/legacypool/async_priced_list.go
+++ b/core/txpool/legacypool/async_priced_list.go
@@ -126,6 +126,10 @@ func (a *asyncPricedList) handle(reheap bool, newOnes []*types.Transaction, toRe
 	}
 }
 
+func (a *asyncPricedList) Staled() int {
+	return a.priced.Staled()
+}
+
 func (a *asyncPricedList) Put(tx *types.Transaction, local bool) {
 	a.add <- &addEvent{tx, local}
 }
@@ -180,4 +184,8 @@ func (a *asyncPricedList) GetBaseFee() *big.Int {
 
 func (a *asyncPricedList) Stop() {
 	close(a.quit)
+}
+
+func (a *asyncPricedList) TxCount() int {
+	return a.priced.TxCount()
 }

--- a/core/txpool/legacypool/async_priced_list.go
+++ b/core/txpool/legacypool/async_priced_list.go
@@ -182,7 +182,7 @@ func (a *asyncPricedList) GetBaseFee() *big.Int {
 	return a.priced.floating.baseFee
 }
 
-func (a *asyncPricedList) Stop() {
+func (a *asyncPricedList) Close() {
 	close(a.quit)
 }
 

--- a/core/txpool/legacypool/async_priced_list.go
+++ b/core/txpool/legacypool/async_priced_list.go
@@ -15,16 +15,6 @@ type addEvent struct {
 	local bool
 }
 
-type discardEvent struct {
-	slots int
-	force bool
-	done  chan *discardResult
-}
-type discardResult struct {
-	discardTxs types.Transactions
-	succ       bool
-}
-
 type asyncPricedList struct {
 	priced         *pricedList
 	floatingLowest atomic.Value
@@ -37,7 +27,6 @@ type asyncPricedList struct {
 	reheap     chan struct{}
 	add        chan *addEvent
 	remove     chan int
-	discard    chan *discardEvent
 	setBaseFee chan *big.Int
 }
 
@@ -48,7 +37,6 @@ func newAsyncPricedList(all *lookup) *asyncPricedList {
 		reheap:     make(chan struct{}),
 		add:        make(chan *addEvent),
 		remove:     make(chan int),
-		discard:    make(chan *discardEvent),
 		setBaseFee: make(chan *big.Int),
 	}
 	go a.run()

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -153,6 +153,8 @@ type BlockChain interface {
 
 // Config are the configuration parameters of the transaction pool.
 type Config struct {
+	EnableAsyncPriced bool // enable async pricedlist. Set as true only --txpool.enableasyncpriced option is enabled
+
 	Locals    []common.Address // Addresses that should be treated by default as local
 	NoLocals  bool             // Whether local transaction handling should be disabled
 	Journal   string           // Journal of local transactions to survive node restarts
@@ -319,7 +321,11 @@ func New(config Config, chain BlockChain) *LegacyPool {
 		pool.locals.add(addr)
 		pool.pendingCache.markLocal(addr)
 	}
-	pool.priced = newPricedList(pool.all)
+	if config.EnableAsyncPriced {
+		pool.priced = newAsyncPricedList(pool.all)
+	} else {
+		pool.priced = newPricedList(pool.all)
+	}
 
 	if (!config.NoLocals || config.JournalRemote) && config.Journal != "" {
 		pool.journal = newTxJournal(config.Journal)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -238,6 +238,9 @@ func (config *Config) sanitize() Config {
 		log.Warn("Sanitizing invalid txpool reannounce time", "provided", conf.ReannounceTime, "updated", time.Minute)
 		conf.ReannounceTime = time.Minute
 	}
+	if config.EnableAsyncPriced {
+		log.Info("Enabling async pricedlist")
+	}
 	return conf
 }
 

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -183,7 +183,11 @@ func validatePoolInternals(pool *LegacyPool) error {
 		return fmt.Errorf("total transaction count %d != %d pending + %d queued", total, pending, queued)
 	}
 	pool.priced.Reheap()
-	priced, remote := pool.priced.urgent.Len()+pool.priced.floating.Len(), pool.all.RemoteCount()
+	if pool.config.EnableAsyncPriced {
+		// sleep a bit to wait for the reheap to finish
+		time.Sleep(50 * time.Millisecond)
+	}
+	priced, remote := pool.priced.TxCount(), pool.all.RemoteCount()
 	if priced != remote {
 		return fmt.Errorf("total priced transaction count %d != %d", priced, remote)
 	}
@@ -1849,10 +1853,126 @@ func TestUnderpricing(t *testing.T) {
 	}
 }
 
+func TestAsyncUnderpricing(t *testing.T) {
+	t.Parallel()
+
+	// Create the pool to test the pricing enforcement with
+	statedb, _ := state.New(types.EmptyRootHash, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := newTestBlockChain(params.TestChainConfig, 1000000, statedb, new(event.Feed))
+
+	config := testTxPoolConfig
+	config.GlobalSlots = 2
+	config.GlobalQueue = 2
+	config.EnableAsyncPriced = true
+
+	pool := New(config, blockchain)
+	pool.Init(config.PriceLimit, blockchain.CurrentBlock(), makeAddressReserver())
+	defer pool.Close()
+
+	// Keep track of transaction events to ensure all executables get announced
+	events := make(chan core.NewTxsEvent, 32)
+	sub := pool.txFeed.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	// Create a number of test accounts and fund them
+	keys := make([]*ecdsa.PrivateKey, 5)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
+	}
+	// Generate and queue a batch of transactions, both pending and queued
+	txs := types.Transactions{}
+
+	txs = append(txs, pricedTransaction(0, 100000, big.NewInt(1), keys[0]))
+	txs = append(txs, pricedTransaction(1, 100000, big.NewInt(2), keys[0]))
+
+	txs = append(txs, pricedTransaction(1, 100000, big.NewInt(1), keys[1]))
+
+	ltx := pricedTransaction(0, 100000, big.NewInt(1), keys[2])
+
+	// Import the batch and that both pending and queued transactions match up
+	pool.addRemotes(txs)
+	pool.addLocal(ltx)
+
+	// sleep a bit to wait for priced transactions to be processed in parallel
+	time.Sleep(50 * time.Millisecond)
+
+	pending, queued := pool.Stats()
+	if pending != 3 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 3)
+	}
+	if queued != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+	if err := validateEvents(events, 3); err != nil {
+		t.Fatalf("original event firing failed: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+	// Ensure that adding an underpriced transaction on block limit fails
+	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(1), keys[1])); !errors.Is(err, txpool.ErrUnderpriced) {
+		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, txpool.ErrUnderpriced)
+	}
+	// Replace a future transaction with a future transaction
+	if err := pool.addRemoteSync(pricedTransaction(1, 100000, big.NewInt(2), keys[1])); err != nil { // +K1:1 => -K1:1 => Pend K0:0, K0:1, K2:0; Que K1:1
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+	// Ensure that adding high priced transactions drops cheap ones, but not own
+	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(3), keys[1])); err != nil { // +K1:0 => -K1:1 => Pend K0:0, K0:1, K1:0, K2:0; Que -
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+	if err := pool.addRemoteSync(pricedTransaction(2, 100000, big.NewInt(4), keys[1])); err != nil { // +K1:2 => -K0:0 => Pend K1:0, K2:0; Que K0:1 K1:2
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+	if err := pool.addRemote(pricedTransaction(3, 100000, big.NewInt(5), keys[1])); err != nil { // +K1:3 => -K0:1 => Pend K1:0, K2:0; Que K1:2 K1:3
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+	// Ensure that replacing a pending transaction with a future transaction fails
+	if err := pool.addRemote(pricedTransaction(5, 100000, big.NewInt(6), keys[1])); err != txpool.ErrFutureReplacePending {
+		t.Fatalf("adding future replace transaction error mismatch: have %v, want %v", err, txpool.ErrFutureReplacePending)
+	}
+	pending, queued = pool.Stats()
+	if pending != 2 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 2)
+	}
+	if queued != 2 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 2)
+	}
+	if err := validateEvents(events, 2); err != nil {
+		t.Fatalf("additional event firing failed: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+	// Ensure that adding local transactions can push out even higher priced ones
+	ltx = pricedTransaction(1, 100000, big.NewInt(0), keys[2])
+	if err := pool.addLocal(ltx); err != nil {
+		t.Fatalf("failed to append underpriced local transaction: %v", err)
+	}
+	ltx = pricedTransaction(0, 100000, big.NewInt(0), keys[3])
+	if err := pool.addLocal(ltx); err != nil {
+		t.Fatalf("failed to add new underpriced local transaction: %v", err)
+	}
+	pending, queued = pool.Stats()
+	if pending != 3 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 3)
+	}
+	if queued != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+	if err := validateEvents(events, 2); err != nil {
+		t.Fatalf("local event firing failed: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
 // Tests that more expensive transactions push out cheap ones from the pool, but
 // without producing instability by creating gaps that start jumping transactions
 // back and forth between queued/pending.
-func TestStableUnderpricingForAsyncPriced(t *testing.T) {
+func TestAsyncStableUnderpricing(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the pricing enforcement with
@@ -1911,6 +2031,117 @@ func TestStableUnderpricingForAsyncPriced(t *testing.T) {
 	}
 	if err := validateEvents(events, 1); err != nil {
 		t.Fatalf("additional event firing failed: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
+// Tests that when the pool reaches its global transaction limit, underpriced
+// transactions (legacy & dynamic fee) are gradually shifted out for more
+// expensive ones and any gapped pending transactions are moved into the queue.
+//
+// Note, local transactions are never allowed to be dropped.
+func TestAsyncUnderpricingDynamicFee(t *testing.T) {
+	t.Parallel()
+
+	pool, _ := setupPoolWithConfig(eip1559Config)
+	defer pool.Close()
+
+	pool.config.GlobalSlots = 2
+	pool.config.GlobalQueue = 2
+	pool.config.EnableAsyncPriced = true
+
+	// Keep track of transaction events to ensure all executables get announced
+	events := make(chan core.NewTxsEvent, 32)
+	sub := pool.txFeed.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	// Create a number of test accounts and fund them
+	keys := make([]*ecdsa.PrivateKey, 4)
+	for i := 0; i < len(keys); i++ {
+		keys[i], _ = crypto.GenerateKey()
+		testAddBalance(pool, crypto.PubkeyToAddress(keys[i].PublicKey), big.NewInt(1000000))
+	}
+
+	// Generate and queue a batch of transactions, both pending and queued
+	txs := types.Transactions{}
+
+	txs = append(txs, dynamicFeeTx(0, 100000, big.NewInt(3), big.NewInt(2), keys[0]))
+	txs = append(txs, pricedTransaction(1, 100000, big.NewInt(2), keys[0]))
+	txs = append(txs, dynamicFeeTx(1, 100000, big.NewInt(2), big.NewInt(1), keys[1]))
+
+	ltx := dynamicFeeTx(0, 100000, big.NewInt(2), big.NewInt(1), keys[2])
+
+	// Import the batch and that both pending and queued transactions match up
+	pool.addRemotes(txs) // Pend K0:0, K0:1; Que K1:1
+	pool.addLocal(ltx)   // +K2:0 => Pend K0:0, K0:1, K2:0; Que K1:1
+
+	pending, queued := pool.Stats()
+	if pending != 3 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 3)
+	}
+	if queued != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+	if err := validateEvents(events, 3); err != nil {
+		t.Fatalf("original event firing failed: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+
+	// Ensure that adding an underpriced transaction fails
+	tx := dynamicFeeTx(0, 100000, big.NewInt(2), big.NewInt(1), keys[1])
+	if err := pool.addRemote(tx); !errors.Is(err, txpool.ErrUnderpriced) { // Pend K0:0, K0:1, K2:0; Que K1:1
+		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, txpool.ErrUnderpriced)
+	}
+
+	// Ensure that adding high priced transactions drops cheap ones, but not own
+	tx = pricedTransaction(0, 100000, big.NewInt(2), keys[1])
+	if err := pool.addRemote(tx); err != nil { // +K1:0, -K1:1 => Pend K0:0, K0:1, K1:0, K2:0; Que -
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+
+	tx = pricedTransaction(1, 100000, big.NewInt(3), keys[1])
+	if err := pool.addRemoteSync(tx); err != nil { // +K1:2, -K0:1 => Pend K0:0 K1:0, K2:0; Que K1:2
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+	tx = dynamicFeeTx(2, 100000, big.NewInt(4), big.NewInt(1), keys[1])
+	if err := pool.addRemoteSync(tx); err != nil { // +K1:3, -K1:0 => Pend K0:0 K2:0; Que K1:2 K1:3
+		t.Fatalf("failed to add well priced transaction: %v", err)
+	}
+	pending, queued = pool.Stats()
+	if pending != 2 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 2)
+	}
+	if queued != 2 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 2)
+	}
+	if err := validateEvents(events, 2); err != nil {
+		t.Fatalf("additional event firing failed: %v", err)
+	}
+	if err := validatePoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+	// Ensure that adding local transactions can push out even higher priced ones
+	ltx = dynamicFeeTx(1, 100000, big.NewInt(0), big.NewInt(0), keys[2])
+	if err := pool.addLocal(ltx); err != nil {
+		t.Fatalf("failed to append underpriced local transaction: %v", err)
+	}
+	ltx = dynamicFeeTx(0, 100000, big.NewInt(0), big.NewInt(0), keys[3])
+	if err := pool.addLocal(ltx); err != nil {
+		t.Fatalf("failed to add new underpriced local transaction: %v", err)
+	}
+	pending, queued = pool.Stats()
+	if pending != 3 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 3)
+	}
+	if queued != 1 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 1)
+	}
+	if err := validateEvents(events, 2); err != nil {
+		t.Fatalf("local event firing failed: %v", err)
 	}
 	if err := validatePoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -2304,7 +2304,6 @@ func TestDualHeapEviction(t *testing.T) {
 	add(false)
 	for baseFee = 0; baseFee <= 1000; baseFee += 100 {
 		pool.priced.SetBaseFee(big.NewInt(int64(baseFee)))
-		pool.priced.Reheap()
 		add(true)
 		check(highCap, "fee cap")
 		add(false)

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -1852,7 +1852,7 @@ func TestUnderpricing(t *testing.T) {
 // Tests that more expensive transactions push out cheap ones from the pool, but
 // without producing instability by creating gaps that start jumping transactions
 // back and forth between queued/pending.
-func TestStableUnderpricing(t *testing.T) {
+func TestStableUnderpricingForAsyncPriced(t *testing.T) {
 	t.Parallel()
 
 	// Create the pool to test the pricing enforcement with

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1296,7 +1296,7 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 	pendingBlobTxs := w.eth.TxPool().Pending(filter)
 
 	packFromTxpoolTimer.UpdateSince(start)
-	log.Debug("packFromTxpoolTimer", "duration", common.PrettyDuration(time.Since(start)), "hash", env.header.Hash())
+	log.Debug("packFromTxpoolTimer", "duration", common.PrettyDuration(time.Since(start)), "hash", env.header.Hash(), "txs", len(pendingPlainTxs))
 
 	// Split the pending transactions into locals and remotes.
 	localPlainTxs, remotePlainTxs := make(map[common.Address][]*txpool.LazyTransaction), pendingPlainTxs


### PR DESCRIPTION
### Description
An "async-reheap" priced list is introduced into txpool to get better performance. The re-heap of the whole transaction pool usually costs hundreds of ms, which blocks more transactions coming into the pool through the Add() function. So we develop a new type of priced list to resolve the bottleneck. 
The "async-reheap" finds the "lowest-priced" transactions async, and stores it into a cache, then it  does the "underpriced" validation quickly by the stored cache.

### Example

add flag ```--txpool.asyncpriced``` to enable this feature.
