### PR TITLE
pevm: fallback to sequencial processor when the TxDAG is too deep

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -177,6 +177,7 @@ var (
 		utils.ParallelTxDAGFlag,
 		utils.ParallelTxDAGFileFlag,
 		utils.ParallelTxDAGSenderPrivFlag,
+		utils.ParallelTxDATMaxDepthRatioFlag,
 		configFileFlag,
 		utils.LogDebugFlag,
 		utils.LogBacktraceAtFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1138,8 +1138,8 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 
 	ParallelTxDATMaxDepthRatioFlag = &cli.Float64Flag{
 		Name:     "parallel.txdag-max-depth-ratio",
-		Usage:    "A ratio to decide whether or not to execute transactions in parallel, it will fallback to sequencial processor if the depth is larger than this value (default = 0.9)",
-		Value:    0.9,
+		Usage:    "A ratio to decide whether or not to execute transactions in parallel, it will fallback to sequencial processor if the depth is larger than this value (default = 1.0)",
+		Value:    1.0,
 		Category: flags.VMCategory,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1138,8 +1138,8 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 
 	ParallelTxDATMaxDepthRatioFlag = &cli.Float64Flag{
 		Name:     "parallel.txdag-max-depth-ratio",
-		Usage:    "A ratio to decide whether or not to execute transactions in parallel, it will fallback to sequencial processor if the depth is larger than this value (default = 1.0)",
-		Value:    1.0,
+		Usage:    "A ratio to decide whether or not to execute transactions in parallel, it will fallback to sequencial processor if the depth is larger than this value (default = 0.9)",
+		Value:    0.9,
 		Category: flags.VMCategory,
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1136,6 +1136,13 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Category: flags.VMCategory,
 	}
 
+	ParallelTxDATMaxDepthRatioFlag = &cli.Float64Flag{
+		Name:     "parallel.txdag-max-depth-ratio",
+		Usage:    "A ratio to decide whether or not to execute transactions in parallel, it will fallback to sequencial processor if the depth is larger than this value (default = 0.9)",
+		Value:    0.9,
+		Category: flags.VMCategory,
+	}
+
 	VMOpcodeOptimizeFlag = &cli.BoolFlag{
 		Name:     "vm.opcode.optimize",
 		Usage:    "enable opcode optimization",
@@ -2055,6 +2062,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 
 	if ctx.IsSet(ParallelTxDAGFileFlag.Name) {
 		cfg.ParallelTxDAGFile = ctx.String(ParallelTxDAGFileFlag.Name)
+	}
+
+	if ctx.IsSet(ParallelTxDATMaxDepthRatioFlag.Name) {
+		cfg.ParallelTxDAGMaxDepthRatio = ctx.Float64(ParallelTxDATMaxDepthRatioFlag.Name)
 	}
 
 	if ctx.IsSet(ParallelTxDAGSenderPrivFlag.Name) {

--- a/core/parallel_state_scheduler.go
+++ b/core/parallel_state_scheduler.go
@@ -382,8 +382,12 @@ func BuildTxLevels(txCount int, dag types.TxDAG) (marked map[int]int, depth int)
 	}
 	// marked is used to record which level that each transaction should be put
 	marked = make(map[int]int, txCount)
-	// currLevel is the level cursor to put the transactions in
-	depth = 0
+	var (
+		// currLevelHasTx marks if the current level has any transaction
+		currLevelHasTx bool
+	)
+
+	depth, currLevelHasTx = 0, false
 	for txIndex := 0; txIndex < txCount; txIndex++ {
 		dep := dag.TxDep(txIndex)
 		switch true {
@@ -391,11 +395,17 @@ func BuildTxLevels(txCount int, dag types.TxDAG) (marked map[int]int, depth int)
 			dep != nil && dep.CheckFlag(types.NonDependentRelFlag):
 			// excluted tx, occupies the whole level
 			// or dependent-to-all tx, occupies the whole level, too
-			marked[txIndex], depth = depth, depth+1
+			if currLevelHasTx {
+				// shift to next level if there are transactions in the current level
+				depth++
+			}
+			marked[txIndex] = depth
+			// occupy the current level
+			depth, currLevelHasTx = depth+1, false
 
 		case dep == nil || len(dep.TxIndexes) == 0:
 			// dependent on none, just put it in the current level
-			marked[txIndex] = depth
+			marked[txIndex], currLevelHasTx = depth, true
 
 		case dep != nil && len(dep.TxIndexes) > 0:
 			// dependent on others
@@ -408,15 +418,22 @@ func BuildTxLevels(txCount int, dag types.TxDAG) (marked map[int]int, depth int)
 			}
 			if prevLevel < 0 {
 				// broken DAG, just ignored it
-				marked[txIndex] = depth
+				marked[txIndex], currLevelHasTx = depth, true
 				continue
 			}
 			// record the level of this tx
 			marked[txIndex] = prevLevel + 1
+			if marked[txIndex] > depth {
+				depth, currLevelHasTx = marked[txIndex], true
+			}
 
 		default:
 			panic("unexpected case")
 		}
 	}
-	return marked, depth
+	// check if the last level has any transaction, to avoid the empty level
+	if !currLevelHasTx {
+		depth--
+	}
+	return marked, depth + 1
 }

--- a/core/parallel_state_scheduler.go
+++ b/core/parallel_state_scheduler.go
@@ -350,8 +350,6 @@ func (tl TxLevel) predictTxDAG(dag types.TxDAG) {
 
 func NewTxLevels(all []*PEVMTxRequest, dag types.TxDAG) TxLevels {
 	var levels TxLevels = make(TxLevels, 0, 8)
-	var currLevel int = 0
-
 	var enlargeLevelsIfNeeded = func(currLevel int, levels *TxLevels) {
 		if len(*levels) <= currLevel {
 			for i := len(*levels); i <= currLevel; i++ {
@@ -367,22 +365,37 @@ func NewTxLevels(all []*PEVMTxRequest, dag types.TxDAG) TxLevels {
 		return TxLevels{all}
 	}
 
-	marked := make(map[int]int, len(all))
-	for _, tx := range all {
-		dep := dag.TxDep(tx.txIndex)
+	// build the levels from the DAG
+	marked, _ := BuildTxLevels(len(all), dag)
+	// put the transactions into the levels
+	for txIndex, tx := range all {
+		level := marked[txIndex]
+		enlargeLevelsIfNeeded(level, &levels)
+		levels[level] = append(levels[level], tx)
+	}
+	return levels
+}
+
+func BuildTxLevels(txCount int, dag types.TxDAG) (marked map[int]int, depth int) {
+	if dag == nil {
+		return make(map[int]int), 0
+	}
+	// marked is used to record which level that each transaction should be put
+	marked = make(map[int]int, txCount)
+	// currLevel is the level cursor to put the transactions in
+	depth = 0
+	for txIndex := 0; txIndex < txCount; txIndex++ {
+		dep := dag.TxDep(txIndex)
 		switch true {
 		case dep != nil && dep.CheckFlag(types.ExcludedTxFlag),
 			dep != nil && dep.CheckFlag(types.NonDependentRelFlag):
 			// excluted tx, occupies the whole level
 			// or dependent-to-all tx, occupies the whole level, too
-			levels = append(levels, TxLevel{tx})
-			marked[tx.txIndex], currLevel = len(levels)-1, len(levels)
+			marked[txIndex], depth = depth, depth+1
 
 		case dep == nil || len(dep.TxIndexes) == 0:
-			// dependent on none
-			enlargeLevelsIfNeeded(currLevel, &levels)
-			levels[currLevel] = append(levels[currLevel], tx)
-			marked[tx.txIndex] = currLevel
+			// dependent on none, just put it in the current level
+			marked[txIndex] = depth
 
 		case dep != nil && len(dep.TxIndexes) > 0:
 			// dependent on others
@@ -395,19 +408,15 @@ func NewTxLevels(all []*PEVMTxRequest, dag types.TxDAG) TxLevels {
 			}
 			if prevLevel < 0 {
 				// broken DAG, just ignored it
-				enlargeLevelsIfNeeded(currLevel, &levels)
-				levels[currLevel] = append(levels[currLevel], tx)
-				marked[tx.txIndex] = currLevel
+				marked[txIndex] = depth
 				continue
 			}
-			enlargeLevelsIfNeeded(prevLevel+1, &levels)
-			levels[prevLevel+1] = append(levels[prevLevel+1], tx)
 			// record the level of this tx
-			marked[tx.txIndex] = prevLevel + 1
+			marked[txIndex] = prevLevel + 1
 
 		default:
 			panic("unexpected case")
 		}
 	}
-	return levels
+	return marked, depth
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -41,6 +41,7 @@ type Config struct {
 	TxDAG                        types.TxDAG
 	EnableParallelUnorderedMerge bool // Whether to enable unordered merge in parallel mode
 	EnableTxParallelMerge        bool // Whether to enable parallel merge in parallel mode
+	TxDAGMaxDepthRatio           float64
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -242,6 +242,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			EnableTxParallelMerge:        config.ParallelTxParallelMerge,
 			ParallelTxNum:                config.ParallelTxNum,
 			EnableOpcodeOptimizations:    config.EnableOpcodeOptimizing,
+			TxDAGMaxDepthRatio:           config.ParallelTxDAGMaxDepthRatio,
 		}
 		cacheConfig = &core.CacheConfig{
 			TrieCleanLimit:       config.TrieCleanCache,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -219,14 +219,14 @@ type Config struct {
 	RollupDisableTxPoolAdmission            bool
 	RollupHaltOnIncompatibleProtocolVersion string
 
-	ParallelTxMode           bool // Whether to execute transaction in parallel mode when do full sync
-	ParallelTxNum            int  // Number of slot for transaction execution
-	EnableOpcodeOptimizing   bool
-	EnableParallelTxDAG      bool
-	ParallelTxDAGFile        string
-	ParallelTxUnorderedMerge bool // Whether to enable unordered merge in parallel mode
-	ParallelTxParallelMerge  bool
-
+	ParallelTxMode             bool // Whether to execute transaction in parallel mode when do full sync
+	ParallelTxNum              int  // Number of slot for transaction execution
+	EnableOpcodeOptimizing     bool
+	EnableParallelTxDAG        bool
+	ParallelTxDAGFile          string
+	ParallelTxUnorderedMerge   bool // Whether to enable unordered merge in parallel mode
+	ParallelTxParallelMerge    bool
+	ParallelTxDAGMaxDepthRatio float64
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.


### PR DESCRIPTION
### Description

A new option is added to improve the performance when the TxDAG contains a deep dependency chain. The performance might become poor when many transactions depend on each other in a block. So we add a threshold option under which the parallel EVM will be enabled, otherwise, the block will be processed by the original EVM in sequential.

### Example

Add flag ```--parallel.txdag-max-depth-ratio``` to enable this feature.  Default to be not enabled.
