### PR TITLE
fix: txpool concurrent map issue

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1496,7 +1496,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 			resetPromoteTimer.Update(promoteDur)
 			resetFeedTimer.Update(sendfeedDur)
 
-			pending, queued := pool.stats()
+			pending, queued := pool.Stats()
 			if reset.newHead != nil && reset.oldHead != nil {
 				log.Info("Transaction pool reorged", "from", reset.oldHead.Number.Uint64(), "to", reset.newHead.Number.Uint64(),
 					"reorgCost", reorgCost, "waittime", waittime, "promoted", len(promoted), "demoted", demoted, "sendFeed", sendFeed, "pending", pending, "queued", queued,

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -609,15 +609,7 @@ func (pool *LegacyPool) Stats() (int, int) {
 // stats retrieves the current pool stats, namely the number of pending and the
 // number of queued (non-executable) transactions.
 func (pool *LegacyPool) stats() (int, int) {
-	pending := 0
-	for _, list := range pool.pending {
-		pending += list.Len()
-	}
-	queued := 0
-	for _, list := range pool.queue {
-		queued += list.Len()
-	}
-	return pending, queued
+	return pool.pendingCounter, pool.queueCounter
 }
 
 // Content retrieves the data content of the transaction pool, returning all the


### PR DESCRIPTION
### Description

This PR is for fixing the issue of concurrent map reading and writing on the map of txpool.queue.
It was introduced by PR #247 , in which the numbers of pending and queued transactions were added to logs. 
The txpool.queue and txpool.pending should always be protected by the mu lock of txpool, So we use Stats() instead of stats();
Besides, there is no need to iterator the pending and queue lists to sum the total numbers. The variables pendingCounter and queueCounter records them.
