### PR TITLE
fix: insert error stage to rpc error in OpSealPayload engine api

### DIFF
--- a/beacon/engine/errors.go
+++ b/beacon/engine/errors.go
@@ -49,6 +49,11 @@ func (e *EngineAPIError) With(err error) *EngineAPIError {
 	}
 }
 
+// SetStage sets error stage in seal payload
+func (e *EngineAPIError) SetStage(stage string) {
+	e.msg = stage + e.msg
+}
+
 var (
 	_ rpc.Error     = new(EngineAPIError)
 	_ rpc.DataError = new(EngineAPIError)

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -31,9 +31,9 @@ import (
 type PayloadVersion byte
 
 const (
-	GetPayloadStage  = "getPayload"
-	NewPayloadStage  = "newPayload"
-	ForkchoiceUpdatedStage = "forkchoiceUpdated"
+	GetPayloadStage        = "sealApiGetPayloadErrStage"
+	NewPayloadStage        = "sealApiNewPayloadErrStage"
+	ForkchoiceUpdatedStage = "sealApiForkchoiceUpdatedErrStage"
 )
 
 var (


### PR DESCRIPTION
### Description

This pr fix error return of engine_opSealPaylaod api, related fix to op-node is https://github.com/bnb-chain/opbnb/pull/259

### Rationale

The error return of original engine_api is chaos and easy lead to bug, the new engine_opSealPayload api followed the original part, and unfortunately triggered bug, which will cause chain stuck if force kill


### Example

n/a
### Changes

insert error stage to rpc error in OpSealPayload engine api
