### PR TITLE
fix(op-geth): fix bundle memory leak

### DIFF
--- a/core/txpool/bundlepool/bundlepool.go
+++ b/core/txpool/bundlepool/bundlepool.go
@@ -361,6 +361,12 @@ func (p *BundlePool) reset(newHead *types.Header) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if len(p.bundles) == 0 {
+		bundleGauge.Update(int64(len(p.bundles)))
+		slotsGauge.Update(int64(p.slots))
+		return
+	}
+
 	// Prune outdated bundles and invalid bundles
 	block := p.chain.GetBlock(newHead.Hash(), newHead.Number.Uint64())
 	txSet := mapset.NewSet[common.Hash]()
@@ -370,6 +376,7 @@ func (p *BundlePool) reset(newHead *types.Header) {
 			txSet.Add(tx.Hash())
 		}
 	}
+	p.bundleHeap = make(BundleHeap, 0)
 	for hash, bundle := range p.bundles {
 		if (bundle.MaxTimestamp != 0 && newHead.Time > bundle.MaxTimestamp) ||
 			(bundle.MaxBlockNumber != 0 && newHead.Number.Cmp(new(big.Int).SetUint64(bundle.MaxBlockNumber)) > 0) {
@@ -378,6 +385,9 @@ func (p *BundlePool) reset(newHead *types.Header) {
 		} else if txSet.Contains(bundle.Txs[0].Hash()) {
 			p.slots -= numSlots(p.bundles[hash])
 			delete(p.bundles, hash)
+		}
+		if p.bundles[hash] != nil {
+			p.bundleHeap.Push(bundle)
 		}
 	}
 	bundleGauge.Update(int64(len(p.bundles)))


### PR DESCRIPTION
### Description

Fix bundle memory leak.

### Rationale

The bundle pool has a memory leak problem, and the bundle heap has no reconstruction logic, which causes the bundle transactions to always fail to GC.

### Example

N/A.

### Changes

Notable changes:
* Add bundle heap reorg when reset bundle pool.
