### PR TITLE
fix: make docker image build and push job work

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GHCR


### PR DESCRIPTION
### Description

Fix the `DockerImage build and push` ci action, which interrupts the automatic image generated & uploaded workflow.

#### The previous failed scene
https://github.com/bnb-chain/op-geth/actions/runs/13053301943/job/37322899096
```
#29 [linux/arm64 builder 8/8] RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
#29 167.3 # net
#29 167.3 gcc: internal compiler error: Segmentation fault signal terminated program cc1
#29 167.3 Please submit a full bug report, with preprocessed source (by using -freport-bug).
#29 167.3 See <https://gitlab.alpinelinux.org/alpine/aports/-/issues> for instructions.
#29 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c cd /go-ethereum && go run build/ci.go install -static ./cmd/geth" did not complete successfully: exit code: 1
------
 > [linux/arm64 builder 8/8] RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth:
167.3 # net
167.3 gcc: internal compiler error: Segmentation fault signal terminated program cc1
167.3 Please submit a full bug report, with preprocessed source (by using -freport-bug).
167.3 See <https://gitlab.alpinelinux.org/alpine/aports/-/issues> for instructions.
```

#### The current fixed-pr succeed scene
https://github.com/bnb-chain/op-geth/actions/runs/13387923709/job/37388777820

### Rationale

This failure was introduced by the PR https://github.com/bnb-chain/op-geth/pull/260; it introduced cgo dependencies, and qemu(default version)+ubuntu-latest(24.04.1)+arm64 will trigger the problem.

There are two ways to workaround this problem:

1. Update ubuntu-latest(24.04.1) -> ubuntu-22.04

Or

2. Specify a newer qemu version

Currently we chose 2

### Example

N/A.

### Changes

Notable changes:
* github workflow config.

