### PR TITLE
fix concurrent issue of local account set in legacypool

### DIFF
--- a/core/txpool/legacypool/cache_for_miner.go
+++ b/core/txpool/legacypool/cache_for_miner.go
@@ -85,10 +85,12 @@ func (pc *cacheForMiner) dump() (map[common.Address]types.Transactions, map[comm
 			pending[addr] = append(pending[addr], tx)
 		}
 	}
+	pc.txLock.Unlock()
+	pc.addrLock.Lock()
 	for addr := range pc.locals {
 		locals[addr] = true
 	}
-	pc.txLock.Unlock()
+	pc.addrLock.Unlock()
 	for _, txs := range pending {
 		// sorted by nonce
 		sort.Sort(types.TxByNonce(txs))

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -690,7 +690,8 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 			staled[tx.Hash()] = struct{}{}
 		}
 	}
-	for addr, txs := range pool.pendingCache.dump() {
+	pendingTxs, localAddrs := pool.pendingCache.dump()
+	for addr, txs := range pendingTxs {
 		// remove nonce too low transactions
 		if len(staled) > 0 {
 			noncetoolow := -1
@@ -705,7 +706,7 @@ func (pool *LegacyPool) Pending(filter txpool.PendingFilter) map[common.Address]
 		}
 
 		// If the miner requests tip enforcement, cap the lists now
-		if minTipBig != nil && !pool.locals.contains(addr) {
+		if minTipBig != nil && !localAddrs[addr] {
 			for i, tx := range txs {
 				if tx.EffectiveGasTipIntCmp(minTipBig, baseFeeBig) < 0 {
 					txs = txs[:i]

--- a/core/txpool/legacypool/nonecache_for_miner.go
+++ b/core/txpool/legacypool/nonecache_for_miner.go
@@ -25,7 +25,7 @@ func (nc *noneCacheForMiner) del(txs types.Transactions, signer types.Signer) {
 	// do nothing
 }
 
-func (nc *noneCacheForMiner) dump() map[common.Address]types.Transactions {
+func (nc *noneCacheForMiner) dump() (map[common.Address]types.Transactions, map[common.Address]bool) {
 	// dump all pending transactions from the pool
 	nc.pool.mu.RLock()
 	defer nc.pool.mu.RUnlock()
@@ -33,7 +33,11 @@ func (nc *noneCacheForMiner) dump() map[common.Address]types.Transactions {
 	for addr, txlist := range nc.pool.pending {
 		pending[addr] = txlist.Flatten()
 	}
-	return pending
+	locals := make(map[common.Address]bool, len(nc.pool.locals.accounts))
+	for addr := range nc.pool.locals.accounts {
+		locals[addr] = true
+	}
+	return pending, locals
 }
 
 func (nc *noneCacheForMiner) markLocal(addr common.Address) {


### PR DESCRIPTION
### Description

There is an concurrent map read & write issue on legacypool.locals when ```--txpool.nolocals=false```. It causes panic.
Here's how it happend:
   1. the ```legacypool.locals``` accounts map is written [here](https://github.com/bnb-chain/op-geth/blob/1534953f61370015af7bbc5071180d2799daaf18/core/txpool/legacypool/legacypool.go#L994), with flag ```--txpool.nolocals=false```.
   2. the ```legacypool.locals``` accounts map is then accessed by the ```Pending()``` method concurrently [here](https://github.com/bnb-chain/op-geth/blob/1534953f61370015af7bbc5071180d2799daaf18/core/txpool/legacypool/legacypool.go#L708), with a none-nil minTip.
  
### Rationale
```
2025-03-13 09:11:46.019	fatal error: concurrent map read and map write
2025-03-13 09:11:46.022	
2025-03-13 09:11:46.022	goroutine 8573 [running]:
2025-03-13 09:11:46.022	github.com/ethereum/go-ethereum/core/txpool/legacypool.(*accountSet).contains(...)
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:2080
2025-03-13 09:11:46.022	github.com/ethereum/go-ethereum/core/txpool/legacypool.(*LegacyPool).Pending(0xc000362780, {0xc00992afc0, 0xc02bfaab80, 0xc02bfaaba0, 0x1, 0x0})
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/core/txpool/legacypool/legacypool.go:708 +0x705
2025-03-13 09:11:46.022	github.com/ethereum/go-ethereum/core/txpool.(*TxPool).Pending(0xc00736b9e0, {0xc00992afc0, 0xc02bfaab80, 0xc02bfaaba0, 0x1, 0x0})
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/core/txpool/txpool.go:407 +0xcd
2025-03-13 09:11:46.022	github.com/ethereum/go-ethereum/miner.(*worker).fillTransactions(0xc00c887440, 0xc017ea7098, 0xc012a248f0)
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/miner/worker.go:1293 +0x22c
2025-03-13 09:11:46.022	github.com/ethereum/go-ethereum/miner.(*worker).generateWork(0xc00c887440, 0xc0168ff080)
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/miner/worker.go:1452 +0xb52
2025-03-13 09:11:46.022	github.com/ethereum/go-ethereum/miner.(*worker).opLoop(0xc00c887440)
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/miner/worker.go:678 +0x7f
2025-03-13 09:11:46.022	created by github.com/ethereum/go-ethereum/miner.newWorker in goroutine 1
2025-03-13 09:11:46.022		github.com/ethereum/go-ethereum/miner/worker.go:343 +0x9f6
2025-03-13 09:11:46.022	
```

### Example
How to replay it:
1. start a miner node with op-geth flat:  ```--txpool.nolocals=false```
2. keep sending transactions to the miner via RPC API, so the transactions will be added into the pool as local ones.
The node should panic after a few minutes.
