### PR TITLE
feat: parse block interval from engine api

### DIFF
--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -27,11 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-var (
-	OldBlockMillisecondsInterval uint64 = 1000
-	NewBlockMillisecondsInterval uint64 = 500
-)
-
 // PayloadVersion denotes the version of PayloadAttributes used to request the
 // building of the payload to commence.
 type PayloadVersion byte

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -133,7 +133,7 @@ func (h *Header) BlockMillisecondTimeUnit() uint64 {
 	if h.MixDigest == (common.Hash{}) {
 		return DefaultBlockIntervalUintCount
 	}
-	count := uint256.NewInt(0).SetBytes2(h.MixDigest[2:2]).Uint64()
+	count := uint256.NewInt(0).SetBytes1(h.MixDigest[2:3]).Uint64()
 	if count == 0 {
 		return DefaultBlockIntervalUintCount
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	DefaultBlockIntervalUintCount uint64 = 2
-	BlockMillisecondsIntervalUint uint64 = 500
+	DefaultBlockIntervalUintCount uint64 = 4
+	BlockMillisecondsIntervalUint uint64 = 250
 )
 
 // A BlockNonce is a 64-bit hash which proves (combined with the

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	OldBlockMillisecondsInterval uint64 = 1000
-	NewBlockMillisecondsInterval uint64 = 500
+	DefaultBlockIntervalUintCount uint64 = 2
+	BlockMillisecondsIntervalUint uint64 = 500
 )
 
 // A BlockNonce is a 64-bit hash which proves (combined with the
@@ -126,10 +126,22 @@ func (h *Header) millisecondes() uint64 {
 func (h *Header) MilliTimestamp() uint64 { return h.Time*1000 + h.millisecondes() }
 
 func (h *Header) NextMilliTimestamp() uint64 {
+	return h.MilliTimestamp() + h.BlockMillisecondTime()
+}
+
+func (h *Header) BlockMillisecondTimeUnit() uint64 {
 	if h.MixDigest == (common.Hash{}) {
-		return h.Time*1000 + OldBlockMillisecondsInterval
+		return DefaultBlockIntervalUintCount
 	}
-	return h.MilliTimestamp() + NewBlockMillisecondsInterval
+	count := uint256.NewInt(0).SetBytes2(h.MixDigest[2:2]).Uint64()
+	if count == 0 {
+		return DefaultBlockIntervalUintCount
+	}
+	return count
+}
+
+func (h *Header) BlockMillisecondTime() uint64 {
+	return h.BlockMillisecondTimeUnit() * BlockMillisecondsIntervalUint
 }
 
 func (h *Header) NextSecondsTimestamp() uint64 { return h.NextMilliTimestamp() / 1000 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -355,6 +355,7 @@ func (miner *Miner) prepareSimulationEnv() (*environment, error) {
 	milliPartBytes := uint256.NewInt(timestamp % 1000).Bytes32()
 	mixDigest[0] = milliPartBytes[30]
 	mixDigest[1] = milliPartBytes[31]
+	mixDigest[2] = parent.MixDigest[2]
 
 	header := &types.Header{
 		ParentHash: parent.Hash(),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1155,7 +1155,7 @@ func (g *generateParams) BlockMillisecondTimeUnit() uint64 {
 	if g.random == (common.Hash{}) {
 		return types.DefaultBlockIntervalUintCount
 	}
-	count := uint256.NewInt(0).SetBytes2(g.random[2:2]).Uint64()
+	count := uint256.NewInt(0).SetBytes1(g.random[2:3]).Uint64()
 	if count == 0 {
 		return types.DefaultBlockIntervalUintCount
 	}


### PR DESCRIPTION
### Description

The op-node writes the BlockInterval into the third byte of the `PrevRandao` in `PayloadAttributes`, with each unit representing 500ms.

### Rationale

op-geth has more control over block time. Previously, if the BlockTime configuration of op-node was greater than 1 second, the excess time would be wasted.

### Example

NO.

### Changes

Notable changes:
NO.
