### PR TITLE
feat: update hash method for adapt bsc prague hardfork

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -93,6 +93,9 @@ type Header struct {
 
 	// ParentBeaconRoot was added by EIP-4788 and is ignored in legacy headers.
 	ParentBeaconRoot *common.Hash `json:"parentBeaconBlockRoot" rlp:"optional"`
+
+	// RequestsHash was added by EIP-7685 and is ignored in legacy headers.
+	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 }
 
 // field type overrides for gencodec

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -36,6 +36,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
 		Hash             common.Hash     `json:"hash"`
 	}
 	var enc Header
@@ -59,6 +60,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
 	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
 	enc.ParentBeaconRoot = h.ParentBeaconRoot
+	enc.RequestsHash = h.RequestsHash
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -86,6 +88,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
 		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
+		RequestsHash     *common.Hash    `json:"requestsHash" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -162,6 +165,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.ParentBeaconRoot != nil {
 		h.ParentBeaconRoot = dec.ParentBeaconRoot
+	}
+	if dec.RequestsHash != nil {
+		h.RequestsHash = dec.RequestsHash
 	}
 	return nil
 }

--- a/core/types/gen_header_rlp.go
+++ b/core/types/gen_header_rlp.go
@@ -42,7 +42,8 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 	_tmp3 := obj.BlobGasUsed != nil
 	_tmp4 := obj.ExcessBlobGas != nil
 	_tmp5 := obj.ParentBeaconRoot != nil
-	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 {
+	_tmp6 := obj.RequestsHash != nil
+	if _tmp1 || _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 {
 		if obj.BaseFee == nil {
 			w.Write(rlp.EmptyString)
 		} else {
@@ -52,32 +53,39 @@ func (obj *Header) EncodeRLP(_w io.Writer) error {
 			w.WriteBigInt(obj.BaseFee)
 		}
 	}
-	if _tmp2 || _tmp3 || _tmp4 || _tmp5 {
+	if _tmp2 || _tmp3 || _tmp4 || _tmp5 || _tmp6 {
 		if obj.WithdrawalsHash == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.WithdrawalsHash[:])
 		}
 	}
-	if _tmp3 || _tmp4 || _tmp5 {
+	if _tmp3 || _tmp4 || _tmp5 || _tmp6 {
 		if obj.BlobGasUsed == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.BlobGasUsed))
 		}
 	}
-	if _tmp4 || _tmp5 {
+	if _tmp4 || _tmp5 || _tmp6 {
 		if obj.ExcessBlobGas == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteUint64((*obj.ExcessBlobGas))
 		}
 	}
-	if _tmp5 {
+	if _tmp5 || _tmp6 {
 		if obj.ParentBeaconRoot == nil {
 			w.Write([]byte{0x80})
 		} else {
 			w.WriteBytes(obj.ParentBeaconRoot[:])
+		}
+	}
+	if _tmp6 {
+		if obj.RequestsHash == nil {
+			w.Write([]byte{0x80})
+		} else {
+			w.WriteBytes(obj.RequestsHash[:])
 		}
 	}
 	w.ListEnd(_tmp0)


### PR DESCRIPTION
### Description

After the BSC prague hardfork, when OPbnb setup a new L2 blockchain is started, the hash of the L1 block corresponding to the L2 gensis block will be verified, and inconsistencies will occur, resulting in startup failure.

https://github.com/bnb-chain/opbnb/blob/02ddbc331594f38c4e7c96a95510010f47f13a64/op-node/rollup/types.go#L290-L299

### Rationale
The incorrect L1 genesis block hash is because the L1 block header adds a RequestsHash field in the Prague hardfork and includes it in the hash calculation:
https://github.com/bnb-chain/bsc/blob/5735d8a56540e8f2fb26d5585de0fa3959bb17b4/miner/worker.go#L1207-L1217

and bsc hash method include this field:
https://github.com/bnb-chain/bsc/blob/5735d8a56540e8f2fb26d5585de0fa3959bb17b4/core/types/gen_header_rlp.go#L84-L90


### Example

N/A.

### Changes

Notable changes:
* hash method.
