### PR TITLE
feat: support generate witness in txdag async process;

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -174,6 +174,7 @@ var (
 		utils.RollupSuperchainUpgradesFlag,
 		utils.ParallelTxDAGFlag,
 		utils.ParallelTxDAGSenderPrivFlag,
+		utils.ParallelTxDAGWitnessGenFlag,
 		configFileFlag,
 		utils.LogDebugFlag,
 		utils.LogBacktraceAtFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1135,6 +1135,13 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value:    "",
 		Category: flags.VMCategory,
 	}
+
+	ParallelTxDAGWitnessGenFlag = &cli.BoolFlag{
+		Name:     "parallel.txdagwitnessgen",
+		Usage:    "enable witness generation for TxDAG",
+		Value:    false,
+		Category: flags.VMCategory,
+	}
 )
 
 var (
@@ -2031,6 +2038,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.IsSet(SelfStatelessValidationFlag.Name) {
 		cfg.EnableStatelessSelfValidation = ctx.Bool(SelfStatelessValidationFlag.Name)
+	}
+
+	if ctx.IsSet(ParallelTxDAGWitnessGenFlag.Name) {
+		cfg.EnableParallelTxDAGWitnessGen = ctx.Bool(ParallelTxDAGWitnessGenFlag.Name)
 	}
 
 	if ctx.IsSet(ParallelTxDAGSenderPrivFlag.Name) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2038,6 +2038,18 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			}
 		}
 
+		// todo: tmp force enable witness generator for testing, will remove it later.
+		//need to collect the witness after state root generation
+		if bc.enableTxDAG && statedb.Witness() != nil {
+			witnesses, err := statedb.MVStates().ResolveROTrieWitness()
+			if err != nil {
+				log.Warn("failed to resolve ROTrieWitness", "err", err)
+				return it.index, err
+			}
+			for _, witness := range witnesses {
+				statedb.Witness().AddState(witness)
+			}
+		}
 		if witness := statedb.Witness(); witness != nil && bc.vmConfig.EnableStatelessSelfValidation {
 			// Remove critical computed fields from the block to force true recalculation
 			context := block.Header()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -305,10 +305,6 @@ type BlockChain struct {
 	processor  Processor // Block transaction processor interface
 	forker     *ForkChoice
 	vmConfig   vm.Config
-
-	// parallel EVM related
-	enableTxDAG           bool
-	enableTxDAGWitnessGen bool
 }
 
 // NewBlockChain returns a fully initialised block chain using information
@@ -2056,6 +2052,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 			}
 		}
 		if witness := statedb.Witness(); witness != nil && bc.vmConfig.EnableStatelessSelfValidation {
+			log.Info("debug witness, start stateless checking", "block", block.NumberU64(), "hash", block.Hash())
 			// Remove critical computed fields from the block to force true recalculation
 			context := block.Header()
 			context.Root = common.Hash{}
@@ -2885,11 +2882,11 @@ func (bc *BlockChain) TxDAGEnabledWhenMine() bool {
 }
 
 func (bc *BlockChain) TxDAGWitnessGenEnabled() bool {
-	return bc.enableTxDAG && bc.enableTxDAGWitnessGen
+	return bc.vmConfig.TxDAGWitnessGenEnabled()
 }
 
 func (bc *BlockChain) SetupTxDAGGeneration(witnessGen bool) {
 	log.Info("node enable TxDAG feature", "witnessGen", witnessGen)
-	bc.enableTxDAG = true
-	bc.enableTxDAGWitnessGen = witnessGen
+	bc.vmConfig.EnableTxDAG = true
+	bc.vmConfig.EnableTxDAGWitnessGen = witnessGen
 }

--- a/core/state/mvstates.go
+++ b/core/state/mvstates.go
@@ -611,6 +611,7 @@ func (s *MVStates) handleRWEvents(items []RWEventItem) {
 			s.asyncRWSet.cannotGasFeeDelay = true
 		// handle witness generation events
 		case ExecutionDoneEvent, AccReadFromDBEvent, SlotReadFromDBEvent:
+			log.Debug("witness generation event", "event", item.Event, "asyncWitnessRunning", s.asyncWitnessRunning, "trieDB", s.trieDB == nil)
 			// if no trieDB, skip witness generation
 			if !s.asyncWitnessRunning || s.trieDB == nil {
 				continue

--- a/core/state/mvstates.go
+++ b/core/state/mvstates.go
@@ -799,7 +799,7 @@ func (s *MVStates) RecordOriginAccRead(addr common.Address, stateRoot common.Has
 	if !s.asyncWitnessRunning {
 		return
 	}
-	log.Debug("witness generation event", "event", AccReadFromDBEvent, "asyncWitnessRunning", s.asyncWitnessRunning, "trieDB", s.trieDB == nil)
+	//	log.Debug("witness generation event", "event", AccReadFromDBEvent, "asyncWitnessRunning", s.asyncWitnessRunning, "trieDB", s.trieDB == nil)
 	s.witnessEventCh <- RWEventItem{
 		Event:     AccReadFromDBEvent,
 		Addr:      addr,
@@ -811,7 +811,7 @@ func (s *MVStates) RecordOriginSlotRead(addr common.Address, slot common.Hash, s
 	if !s.asyncWitnessRunning {
 		return
 	}
-	log.Debug("witness generation event", "event", SlotReadFromDBEvent, "asyncWitnessRunning", s.asyncWitnessRunning, "trieDB", s.trieDB == nil)
+	//	log.Debug("witness generation event", "event", SlotReadFromDBEvent, "asyncWitnessRunning", s.asyncWitnessRunning, "trieDB", s.trieDB == nil)
 	s.witnessEventCh <- RWEventItem{
 		Event:       SlotReadFromDBEvent,
 		Addr:        addr,

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -261,7 +261,7 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		value.SetBytes(val)
 	}
 	// Schedule the resolved storage slots for prefetching if it's enabled.
-	log.Debug("getcommittedstate from db", "addr", s.address, "key", key, "value", value, "stateRoot", s.db.originalRoot, "originRoot", s.origin.Root)
+	log.Debug("getcommittedstate from db", "addr", s.address, "key", key, "value", value)
 	if s.db.EnableAsyncWitnessGen() && s.data.Root != types.EmptyRootHash {
 		s.db.mvStates.RecordOriginSlotRead(s.address, key, s.db.originalRoot, s.origin.Root)
 	} else if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -261,7 +261,7 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		value.SetBytes(val)
 	}
 	// Schedule the resolved storage slots for prefetching if it's enabled.
-	log.Debug("getcommittedstate from db", "addr", s.address, "key", key, "stateRoot", s.db.originalRoot, "originRoot", s.origin.Root)
+	log.Debug("getcommittedstate from db", "addr", s.address, "key", key, "value", value, "stateRoot", s.db.originalRoot, "originRoot", s.origin.Root)
 	if s.db.EnableAsyncWitnessGen() && s.data.Root != types.EmptyRootHash {
 		s.db.mvStates.RecordOriginSlotRead(s.address, key, s.db.originalRoot, s.origin.Root)
 	} else if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -261,6 +261,7 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		value.SetBytes(val)
 	}
 	// Schedule the resolved storage slots for prefetching if it's enabled.
+	log.Debug("getcommittedstate from db", "addr", s.address, "key", key, "stateRoot", s.db.originalRoot, "originRoot", s.origin.Root)
 	if s.db.EnableAsyncWitnessGen() && s.data.Root != types.EmptyRootHash {
 		s.db.mvStates.RecordOriginSlotRead(s.address, key, s.db.originalRoot, s.origin.Root)
 	} else if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -261,11 +261,10 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		value.SetBytes(val)
 	}
 	// Schedule the resolved storage slots for prefetching if it's enabled.
-	if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {
-		s.db.prefetcher.prefetch(s.addrHash, s.origin.Root, s.address, nil, []common.Hash{key}, true)
-	}
-	if s.db.mvStates != nil && s.data.Root != types.EmptyRootHash {
+	if s.db.EnableAsyncWitnessGen() && s.data.Root != types.EmptyRootHash {
 		s.db.mvStates.RecordOriginSlotRead(s.address, key, s.db.originalRoot, s.origin.Root)
+	} else if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {
+		s.db.prefetcher.prefetch(s.addrHash, s.origin.Root, s.address, nil, []common.Hash{key}, true)
 	}
 	s.originStorage[key] = value
 	return value

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -264,6 +264,9 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 	if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {
 		s.db.prefetcher.prefetch(s.addrHash, s.origin.Root, s.address, nil, []common.Hash{key}, true)
 	}
+	if s.db.mvStates != nil && s.data.Root != types.EmptyRootHash {
+		s.db.mvStates.RecordOriginSlotRead(s.address, key, s.db.originalRoot, s.origin.Root)
+	}
 	s.originStorage[key] = value
 	return value
 }

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -334,13 +334,13 @@ func (s *stateObject) finaliseRWSet() {
 	}
 
 	if s.dirtyNonce != nil && *s.dirtyNonce != s.data.Nonce {
-		ms.RecordAccountWrite(s.address, types.AccountNonce)
+		ms.RecordAccountWrite(s.address, AccountNonce)
 	}
 	if s.dirtyBalance != nil && s.dirtyBalance.Cmp(s.data.Balance) != 0 {
-		ms.RecordAccountWrite(s.address, types.AccountBalance)
+		ms.RecordAccountWrite(s.address, AccountBalance)
 	}
 	if s.dirtyCodeHash != nil && !slices.Equal(s.dirtyCodeHash, s.data.CodeHash) {
-		ms.RecordAccountWrite(s.address, types.AccountCodeHash)
+		ms.RecordAccountWrite(s.address, AccountCodeHash)
 	}
 }
 

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -261,7 +261,6 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 		value.SetBytes(val)
 	}
 	// Schedule the resolved storage slots for prefetching if it's enabled.
-	log.Debug("getcommittedstate from db", "addr", s.address, "key", key, "value", value)
 	if s.db.EnableAsyncWitnessGen() && s.data.Root != types.EmptyRootHash {
 		s.db.mvStates.RecordOriginSlotRead(s.address, key, s.db.originalRoot, s.origin.Root)
 	} else if s.db.prefetcher != nil && s.data.Root != types.EmptyRootHash {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -355,11 +355,14 @@ func (s *stateObject) finaliseRWSet() {
 // storage change at all.
 func (s *stateObject) updateTrie() (Trie, error) {
 	// Make sure all dirty slots are finalized into the pending storage area
-	// s.finalise(false)
+	s.finalise(false)
 
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
-		return s.trie, nil
+		if s.db.witness != nil || len(s.originStorage) == 0 {
+			log.Info("debug witness, updateTrie, no pending/origin storage", "addr", s.address)
+			return s.trie, nil
+		}
 	}
 	// Track the amount of time wasted on updating the storage trie
 	if metrics.EnabledExpensive {

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -355,7 +355,7 @@ func (s *stateObject) finaliseRWSet() {
 // storage change at all.
 func (s *stateObject) updateTrie() (Trie, error) {
 	// Make sure all dirty slots are finalized into the pending storage area
-	s.finalise(false)
+	// s.finalise(false)
 
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
@@ -406,12 +406,20 @@ func (s *stateObject) updateTrie() (Trie, error) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		// Perform trie updates before deletions.  This prevents resolution of unnecessary trie nodes
+		//  in circumstances similar to the following:
+		//
+		// Consider nodes `A` and `B` who share the same full node parent `P` and have no other siblings.
+		// During the execution of a block:
+		// - `A` is deleted,
+		// - `C` is created, and also shares the parent `P`.
+		// If the deletion is handled first, then `P` would be left with only one child, thus collapsed
+		// into a shortnode. This requires `B` to be resolved from disk.
+		// Whereas if the created node is handled first, then the collapse is avoided, and `B` is not resolved.
+		var deletions []common.Hash
 		for key, value := range dirtyStorage {
 			if len(value) == 0 {
-				if err := tr.DeleteStorage(s.address, key[:]); err != nil {
-					s.db.setError(err)
-				}
-				s.db.StorageDeleted += 1
+				deletions = append(deletions, key)
 			} else {
 				if err := tr.UpdateStorage(s.address, key[:], value); err != nil {
 					s.db.setError(err)
@@ -420,6 +428,12 @@ func (s *stateObject) updateTrie() (Trie, error) {
 			}
 			// Cache the items for preloading
 			usedStorage = append(usedStorage, key)
+		}
+		for _, key := range deletions {
+			if err := tr.DeleteStorage(s.address, key[:]); err != nil {
+				s.db.setError(err)
+			}
+			s.db.StorageDeleted += 1
 		}
 	}()
 	// If state snapshotting is active, cache the data til commit

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -359,7 +359,7 @@ func (s *stateObject) updateTrie() (Trie, error) {
 
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
-		if s.db.witness != nil || len(s.originStorage) == 0 {
+		if s.db.witness == nil || len(s.originStorage) == 0 {
 			log.Info("debug witness, updateTrie, no pending/origin storage", "addr", s.address)
 			return s.trie, nil
 		}

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -726,6 +726,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		}
 	}
 
+	log.Debug("getStateObject from db", "addr", addr, "stateRoot", s.originalRoot)
 	if s.EnableAsyncWitnessGen() {
 		s.mvStates.RecordOriginAccRead(addr, s.originalRoot)
 	} else if s.prefetcher != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -730,6 +730,9 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 			log.Error("Failed to prefetch account", "addr", addr, "err", err)
 		}
 	}
+	if s.mvStates != nil {
+		s.mvStates.RecordOriginAccRead(addr, s.originalRoot)
+	}
 
 	// Insert into the live set
 	obj := newObject(s, addr, data)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -726,7 +726,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		}
 	}
 
-	log.Debug("getStateObject from db", "addr", addr, "stateRoot", s.originalRoot)
+	log.Debug("getStateObject from db", "addr", addr, "data", data, "stateRoot", s.originalRoot)
 	if s.EnableAsyncWitnessGen() {
 		s.mvStates.RecordOriginAccRead(addr, s.originalRoot)
 	} else if s.prefetcher != nil {
@@ -1803,12 +1803,7 @@ func (s *StateDB) StopTxRecorder() {
 }
 
 func (s *StateDB) ResetMVStates(txCount int, feeReceivers []common.Address) *MVStates {
-	var trieDB Database
-	// if exists witness, use the same trieDB
-	if s.witness != nil {
-		trieDB = s.db
-	}
-	s.mvStates = NewMVStates(txCount, feeReceivers, trieDB)
+	s.mvStates = NewMVStates(txCount, feeReceivers, s.db)
 	return s.mvStates
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -726,7 +726,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		}
 	}
 
-	log.Debug("getStateObject from db", "addr", addr, "data", data, "stateRoot", s.originalRoot)
+	log.Debug("getStateObject from db", "addr", addr, "data", data)
 	if s.EnableAsyncWitnessGen() {
 		s.mvStates.RecordOriginAccRead(addr, s.originalRoot)
 	} else if s.prefetcher != nil {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -118,7 +118,8 @@ type StateDB struct {
 	logSize uint
 
 	// parallel EVM related
-	mvStates *MVStates
+	mvStates        *MVStates
+	asyncWitnessGen bool
 
 	// Preimages occurred seen by VM in the scope of block.
 	preimages map[common.Hash][]byte
@@ -1879,6 +1880,7 @@ func (s *StateDB) StartAsyncTxDAG(asyncWitnessGen bool) {
 	if s.witness != nil && asyncWitnessGen {
 		log.Debug("start witness generation in TxDAG component")
 		s.mvStates.EnableAsyncWitnessGen()
+		s.asyncWitnessGen = true
 	}
 }
 
@@ -1886,7 +1888,7 @@ func (s *StateDB) EnableAsyncWitnessGen() bool {
 	if s.mvStates == nil {
 		return false
 	}
-	return s.witness != nil && s.mvStates.asyncWitnessRunning.Load()
+	return s.witness != nil && s.asyncWitnessGen
 }
 
 // copySet returns a deep-copied set.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1128,13 +1128,15 @@ func (s *StateDB) AccountsIntermediateRoot() {
 			if len(obj.originStorage) == 0 {
 				continue
 			}
+			if _, ok := s.stateObjectsPending[obj.address]; ok {
+				continue
+			}
 			if trie := obj.getPrefetchedTrie(); trie != nil {
 				s.witness.AddState(trie.Witness())
 			} else if obj.trie != nil {
 				s.witness.AddState(obj.trie.Witness())
 			}
 		}
-
 	}
 	wg.Wait()
 }

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -410,6 +410,9 @@ func (s *StateDB) GetCode(addr common.Address) []byte {
 	}
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		if s.witness != nil {
+			s.witness.AddCode(stateObject.Code())
+		}
 		return stateObject.Code()
 	}
 	return nil
@@ -421,6 +424,9 @@ func (s *StateDB) GetCodeSize(addr common.Address) int {
 	}
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		if s.witness != nil {
+			s.witness.AddCode(stateObject.Code())
+		}
 		return stateObject.CodeSize()
 	}
 	return 0
@@ -1159,15 +1165,29 @@ func (s *StateDB) StateIntermediateRoot() common.Hash {
 	}
 
 	usedAddrs := make([]common.Address, 0, len(s.stateObjectsPending))
+	// Perform updates before deletions.  This prevents resolution of unnecessary trie nodes
+	// in circumstances similar to the following:
+	//
+	// Consider nodes `A` and `B` who share the same full node parent `P` and have no other siblings.
+	// During the execution of a block:
+	// - `A` self-destructs,
+	// - `C` is created, and also shares the parent `P`.
+	// If the self-destruct is handled first, then `P` would be left with only one child, thus collapsed
+	// into a shortnode. This requires `B` to be resolved from disk.
+	// Whereas if the created node is handled first, then the collapse is avoided, and `B` is not resolved.
+	var deletedAddrs []common.Address
 	for addr := range s.stateObjectsPending {
 		if obj := s.stateObjects[addr]; obj.deleted {
-			s.deleteStateObject(obj)
-			s.AccountDeleted += 1
+			deletedAddrs = append(deletedAddrs, obj.address)
 		} else {
 			s.updateStateObject(obj)
 			s.AccountUpdated += 1
 		}
 		usedAddrs = append(usedAddrs, addr) // Copy needed for closure
+	}
+	for _, deletedAddr := range deletedAddrs {
+		s.deleteStateObject(s.stateObjects[deletedAddr])
+		s.AccountDeleted += 1
 	}
 	if s.prefetcher != nil {
 		s.prefetcher.used(common.Hash{}, s.originalRoot, usedAddrs, nil)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -90,6 +90,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 	statedb.MarkFullProcessed()
 	if cfg.EnableTxDAG {
+		log.Debug("debug witness, start txdag", "block", block.NumberU64(), "hash", block.Hash(), "cfg", cfg)
 		feeReceivers := []common.Address{context.Coinbase, params.OptimismBaseFeeRecipient, params.OptimismL1FeeRecipient}
 		statedb.ResetMVStates(len(block.Transactions()), feeReceivers)
 		statedb.StartAsyncTxDAG(cfg.TxDAGWitnessGenEnabled())

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -92,7 +92,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if cfg.EnableTxDAG {
 		feeReceivers := []common.Address{context.Coinbase, params.OptimismBaseFeeRecipient, params.OptimismL1FeeRecipient}
 		statedb.ResetMVStates(len(block.Transactions()), feeReceivers)
-		statedb.StartAsyncTxDAG(p.bc.TxDAGWitnessGenEnabled())
+		statedb.StartAsyncTxDAG(cfg.TxDAGWitnessGenEnabled())
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -128,6 +128,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	}
 
 	if statedb.MVStates() != nil {
+		statedb.MVStates().RecordExecutionDone()
 		statedb.MVStates().BatchRecordHandle()
 	}
 	// Fail if Shanghai not enabled and len(withdrawals) is non-zero.

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -89,8 +89,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
 	statedb.MarkFullProcessed()
+	log.Debug("debug witness, try start txdag", "block", block.NumberU64(), "hash", block.Hash(), "cfg", cfg)
 	if cfg.EnableTxDAG {
-		log.Debug("debug witness, start txdag", "block", block.NumberU64(), "hash", block.Hash(), "cfg", cfg)
 		feeReceivers := []common.Address{context.Coinbase, params.OptimismBaseFeeRecipient, params.OptimismL1FeeRecipient}
 		statedb.ResetMVStates(len(block.Transactions()), feeReceivers)
 		statedb.StartAsyncTxDAG(cfg.TxDAGWitnessGenEnabled())

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -91,7 +91,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	statedb.MarkFullProcessed()
 	if cfg.EnableTxDAG {
 		feeReceivers := []common.Address{context.Coinbase, params.OptimismBaseFeeRecipient, params.OptimismL1FeeRecipient}
-		statedb.ResetMVStates(len(block.Transactions()), feeReceivers).EnableAsyncGen()
+		statedb.ResetMVStates(len(block.Transactions()), feeReceivers)
+		statedb.StartAsyncTxDAG(p.bc.TxDAGWitnessGenEnabled())
 	}
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -17,6 +17,8 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
@@ -67,7 +69,13 @@ func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *typ
 
 	// Run the stateless blocks processing and self-validate certain fields
 	receipts, _, usedGas, err := processor.Process(block, db, vm.Config{})
-	log.Info("print witness execute receipt", "block", block, "receipt", receipts, "vm_config", vm.Config{})
+	var receiptString string
+	for i, receipt := range receipts {
+		receiptString += fmt.Sprintf("\n  %d: cumulative: %v gas: %v contract: %v status: %v tx: %v logs: %v bloom: %x state: %x",
+			i, receipt.CumulativeGasUsed, receipt.GasUsed, receipt.ContractAddress.Hex(),
+			receipt.Status, receipt.TxHash.Hex(), receipt.Logs, receipt.Bloom, receipt.PostState)
+	}
+	log.Info("print witness execute receipt", "block", block, "receipt", receiptString, "vm_config", vm.Config{})
 	if err != nil {
 		return common.Hash{}, common.Hash{}, err
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -251,9 +251,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		code := evm.StateDB.GetCode(addr)
-		if witness := evm.StateDB.Witness(); witness != nil {
-			witness.AddCode(code)
-		}
 		if len(code) == 0 {
 			ret, err = nil, nil // gas is unchanged
 		} else {
@@ -334,9 +331,6 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 			code := evm.StateDB.GetCode(addrCopy)
 			codeHash := evm.StateDB.GetCodeHash(addrCopy)
 			contract.optimized, code = tryGetOptimizedCode(evm, codeHash, code)
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(code)
-			}
 			contract.SetCallCode(&addrCopy, codeHash, code)
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
@@ -346,9 +340,6 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 			// The contract is a scoped environment for this execution context only.
 			contract := NewContract(caller, AccountRef(caller.Address()), value, gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(evm.StateDB.GetCode(addrCopy))
-			}
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		}
@@ -398,9 +389,6 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 			codeHash := evm.StateDB.GetCodeHash(addrCopy)
 			contract.optimized, code = tryGetOptimizedCode(evm, codeHash, code)
 			contract.SetCallCode(&addrCopy, codeHash, code)
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(code)
-			}
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		} else {
@@ -408,9 +396,6 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 			// Initialise a new contract and make initialise the delegate values
 			contract := NewContract(caller, AccountRef(caller.Address()), nil, gas).AsDelegate()
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(evm.StateDB.GetCode(addrCopy))
-			}
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		}
@@ -469,9 +454,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 			codeHash := evm.StateDB.GetCodeHash(addrCopy)
 			contract.optimized, code = tryGetOptimizedCode(evm, codeHash, code)
 			contract.SetCallCode(&addrCopy, codeHash, code)
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(code)
-			}
 			// When an error was returned by the EVM or when setting the creation code
 			// above we revert to the snapshot and consume any gas remaining. Additionally
 			// when we're in Homestead this also counts for code storage gas errors.
@@ -486,9 +468,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 			// The contract is a scoped environment for this execution context only.
 			contract := NewContract(caller, AccountRef(addrCopy), new(uint256.Int), gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(evm.StateDB.GetCode(addrCopy))
-			}
 			// When an error was returned by the EVM or when setting the creation code
 			// above we revert to the snapshot and consume any gas remaining. Additionally
 			// when we're in Homestead this also counts for code storage gas errors.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -341,10 +341,6 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
-	address := slot.Bytes20()
-	if witness := interpreter.evm.StateDB.Witness(); witness != nil {
-		witness.AddCode(interpreter.evm.StateDB.GetCode(address))
-	}
 	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20())))
 	return nil, nil
 }
@@ -387,9 +383,6 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	}
 	addr := common.Address(a.Bytes20())
 	code := interpreter.evm.StateDB.GetCode(addr)
-	if witness := interpreter.evm.StateDB.Witness(); witness != nil {
-		witness.AddCode(code)
-	}
 	codeCopy := getData(code, uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -36,7 +36,12 @@ type Config struct {
 	OptimismPrecompileOverrides   PrecompileOverrides // Precompile overrides for Optimism
 	EnableOpcodeOptimizations     bool                // Enable opcode optimization
 	EnableTxDAG                   bool                // parallel EVM related
+	EnableTxDAGWitnessGen         bool                // parallel EVM related
 	EnableStatelessSelfValidation bool                // Generate execution witnesses and self-check against them (testing purpose)
+}
+
+func (c *Config) TxDAGWitnessGenEnabled() bool {
+	return c.EnableTxDAG && c.EnableTxDAGWitnessGen
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -17,7 +17,11 @@
 package vm
 
 import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -245,7 +249,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// execute the operation
 		res, err = operation.execute(&pc, in, callContext)
 		if err != nil {
-			log.Info("debug witness, failed to operation execute", "error", err)
 			break
 		}
 		pc++
@@ -253,6 +256,35 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 	if err == errStopToken {
 		err = nil // clear stop token error
+	}
+
+	if err != nil {
+		// Convert ret to readable error message if it's a revert
+		var errorMsg string
+		if len(res) >= 4 && hexutil.Encode(res[:4]) == "0x08c379a0" {
+			// Try to decode the revert reason
+			errorAbi, _ := abi.JSON(strings.NewReader(`[{"name":"Error","type":"function","inputs":[{"name":"message","type":"string"}]}]`))
+			unpacked, err := errorAbi.Unpack("Error", res[4:])
+			if err == nil && len(unpacked) > 0 {
+				errorMsg = unpacked[0].(string)
+			}
+		}
+
+		// If we couldn't decode the revert reason, use the raw hex
+		if errorMsg == "" {
+			errorMsg = hexutil.Encode(res)
+		}
+
+		log.Info("debug witness, failed to operation execute",
+			"error", err,
+			"op", op,
+			"pc", pc,
+			"res", res,
+			"revert_reason", errorMsg,
+			"raw_return", hexutil.Encode(res),
+			"contract_addr", contract.Address(),
+			"contract_code_hash", contract.CodeHash,
+		)
 	}
 
 	return res, err

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -475,6 +475,7 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	}
 
 	statedb.StartPrefetcher("debug_execution_witness", witness)
+	fmt.Println("start prefetcher")
 	defer statedb.StopPrefetcher()
 
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
@@ -484,6 +485,19 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 
 	if err := blockchain.Validator().ValidateState(block, statedb, receipts, usedGas, false, false); err != nil {
 		return nil, fmt.Errorf("failed to validate block %d: %w", block.Number(), err)
+	}
+
+	if blockchain.TxDAGWitnessGenEnabled() {
+		witnesses, err := statedb.MVStates().ResolveROTrieWitness()
+		if err != nil {
+			log.Warn("failed to resolve ROTrieWitness", "err", err)
+			return nil, fmt.Errorf("failed to resolve ROTrieWitness: %w", err)
+		}
+		log.Debug("ResolveROTrieWitness from txdag component", "hash", block.Hash(), "number", block.NumberU64(), "witnesses", len(witnesses))
+		for _, witness := range witnesses {
+			log.Debug("add witness to statedb", "hash", block.Hash(), "number", block.NumberU64(), "witness", len(witness))
+			statedb.Witness().AddState(witness)
+		}
 	}
 
 	return witness, nil

--- a/eth/api_debug_test.go
+++ b/eth/api_debug_test.go
@@ -253,3 +253,66 @@ func TestExecutionWitness(t *testing.T) {
 	_, _, err = core.ExecuteStateless(params.TestChainConfig, vm.Config{}, block, witness)
 	require.NoError(t, err)
 }
+
+func TestTxDAGExecutionWitness(t *testing.T) {
+	t.Parallel()
+
+	// Create transactions
+	privateKey, err := crypto.GenerateKey() // Generate a new private key
+	require.NoError(t, err)
+
+	// Get the address from the private key
+	fromAddr := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	// Create a database pre-initialize with a genesis block
+	db := rawdb.NewMemoryDatabase()
+	gspec := &core.Genesis{
+		Config: params.TestChainConfig,
+		Alloc: types.GenesisAlloc{
+			testAddr: {Balance: big.NewInt(1000000)},
+			fromAddr: {Balance: big.NewInt(1000000000000000000)},
+		},
+	}
+
+	chain, _ := core.NewBlockChain(db, nil, gspec, nil, ethash.NewFaker(), vm.Config{}, nil, nil)
+	chain.SetupTxDAGGeneration(true)
+	blockNum := 10
+
+	signer := types.LatestSigner(params.TestChainConfig)
+	baseFee := big.NewInt(875000000)
+
+	nonce := uint64(0)
+	_, bs, _ := core.GenerateChainWithGenesis(gspec, ethash.NewFaker(), blockNum, func(i int, gen *core.BlockGen) {
+		if i%2 == 0 && i > 0 { // Add transactions  starting from block 2
+			for j := 0; j < 2; j++ { // Add 2 transactions per block
+				tx := types.NewTx(&types.DynamicFeeTx{
+					ChainID:   params.TestChainConfig.ChainID,
+					Nonce:     nonce,
+					GasTipCap: big.NewInt(1000000000),
+					GasFeeCap: new(big.Int).Mul(baseFee, big.NewInt(2)),
+					Gas:       21000,
+					To:        &testAddr,
+					Value:     big.NewInt(100),
+					Data:      nil,
+				})
+				signedTx, err := types.SignTx(tx, signer, privateKey)
+				require.NoError(t, err)
+				gen.AddTx(signedTx)
+				nonce++
+			}
+		}
+	})
+
+	if _, err := chain.InsertChain(bs); err != nil {
+		panic(err)
+	}
+
+	block := chain.GetBlockByNumber(uint64(blockNum - 1))
+	require.NotNil(t, block)
+
+	witness, err := generateWitness(chain, block)
+	require.NoError(t, err)
+
+	_, _, err = core.ExecuteStateless(params.TestChainConfig, vm.Config{}, block, witness)
+	require.NoError(t, err)
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -289,7 +289,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, err
 	}
 	if config.EnableParallelTxDAG {
-		eth.blockchain.SetupTxDAGGeneration()
+		eth.blockchain.SetupTxDAGGeneration(config.EnableParallelTxDAGWitnessGen)
 	}
 	if chainConfig := eth.blockchain.Config(); chainConfig.Optimism != nil { // config.Genesis.Config.ChainID cannot be used because it's based on CLI flags only, thus default to mainnet L1
 		config.NetworkId = chainConfig.ChainID.Uint64() // optimism defaults eth network ID to chain ID

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -224,6 +224,7 @@ type Config struct {
 	EnableOpcodeOptimizing        bool
 	EnableParallelTxDAG           bool
 	EnableStatelessSelfValidation bool
+	EnableParallelTxDAGWitnessGen bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain config.

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -80,6 +80,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RollupHaltOnIncompatibleProtocolVersion string
 		EnableOpcodeOptimizing                  bool
 		EnableParallelTxDAG                     bool
+		EnableParallelTxDAGWitnessGen           bool
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -143,6 +144,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RollupHaltOnIncompatibleProtocolVersion = c.RollupHaltOnIncompatibleProtocolVersion
 	enc.EnableOpcodeOptimizing = c.EnableOpcodeOptimizing
 	enc.EnableParallelTxDAG = c.EnableParallelTxDAG
+	enc.EnableParallelTxDAGWitnessGen = c.EnableParallelTxDAGWitnessGen
 	return &enc, nil
 }
 
@@ -210,6 +212,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RollupHaltOnIncompatibleProtocolVersion *string
 		EnableOpcodeOptimizing                  *bool
 		EnableParallelTxDAG                     *bool
+		EnableParallelTxDAGWitnessGen           *bool
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -397,6 +400,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.EnableParallelTxDAG != nil {
 		c.EnableParallelTxDAG = *dec.EnableParallelTxDAG
+	}
+	if dec.EnableParallelTxDAGWitnessGen != nil {
+		c.EnableParallelTxDAGWitnessGen = *dec.EnableParallelTxDAGWitnessGen
 	}
 	return nil
 }

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -80,6 +80,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RollupHaltOnIncompatibleProtocolVersion string
 		EnableOpcodeOptimizing                  bool
 		EnableParallelTxDAG                     bool
+		EnableStatelessSelfValidation           bool
 		EnableParallelTxDAGWitnessGen           bool
 	}
 	var enc Config
@@ -144,6 +145,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RollupHaltOnIncompatibleProtocolVersion = c.RollupHaltOnIncompatibleProtocolVersion
 	enc.EnableOpcodeOptimizing = c.EnableOpcodeOptimizing
 	enc.EnableParallelTxDAG = c.EnableParallelTxDAG
+	enc.EnableStatelessSelfValidation = c.EnableStatelessSelfValidation
 	enc.EnableParallelTxDAGWitnessGen = c.EnableParallelTxDAGWitnessGen
 	return &enc, nil
 }
@@ -212,6 +214,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RollupHaltOnIncompatibleProtocolVersion *string
 		EnableOpcodeOptimizing                  *bool
 		EnableParallelTxDAG                     *bool
+		EnableStatelessSelfValidation           *bool
 		EnableParallelTxDAGWitnessGen           *bool
 	}
 	var dec Config
@@ -400,6 +403,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.EnableParallelTxDAG != nil {
 		c.EnableParallelTxDAG = *dec.EnableParallelTxDAG
+	}
+	if dec.EnableStatelessSelfValidation != nil {
+		c.EnableStatelessSelfValidation = *dec.EnableStatelessSelfValidation
 	}
 	if dec.EnableParallelTxDAGWitnessGen != nil {
 		c.EnableParallelTxDAGWitnessGen = *dec.EnableParallelTxDAGWitnessGen

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1464,7 +1464,7 @@ func (w *worker) generateWork(genParams *generateParams) *newPayloadResult {
 			go func() {
 				defer wg.Done()
 				if w.chain.TxDAGEnabledWhenMine() {
-					newWork.state.MVStates().EnableAsyncGen()
+					newWork.state.StartAsyncTxDAG(w.chain.TxDAGWitnessGenEnabled())
 				}
 				err := w.fillTransactions(interrupt, newWork)
 				if errors.Is(err, errBlockInterruptedByTimeout) {
@@ -1476,7 +1476,7 @@ func (w *worker) generateWork(genParams *generateParams) *newPayloadResult {
 				}
 			}()
 			if w.chain.TxDAGEnabledWhenMine() {
-				work.state.MVStates().EnableAsyncGen()
+				work.state.StartAsyncTxDAG(w.chain.TxDAGWitnessGenEnabled())
 			}
 			err := w.fillTransactionsAndBundles(interrupt, work)
 			wg.Wait()
@@ -1490,7 +1490,7 @@ func (w *worker) generateWork(genParams *generateParams) *newPayloadResult {
 			}
 		} else {
 			if w.chain.TxDAGEnabledWhenMine() {
-				work.state.MVStates().EnableAsyncGen()
+				work.state.StartAsyncTxDAG(w.chain.TxDAGWitnessGenEnabled())
 			}
 			err := w.fillTransactions(interrupt, work)
 			timer.Stop() // don't need timeout interruption any more
@@ -1520,7 +1520,7 @@ func (w *worker) generateWork(genParams *generateParams) *newPayloadResult {
 	}
 
 	//need to collect the witness after state root generation
-	if w.chain.TxDAGEnabledWhenMine() && work.state.Witness() != nil {
+	if work.state.EnableAsyncWitnessGen() {
 		w.appendWitnessFromTxDAG(work)
 	}
 	if block.Root() == (common.Hash{}) {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -255,7 +255,7 @@ func generateTxDAGGaslessBlock(t *testing.T, enableMev, enableTxDAG bool) {
 	w, b := newTestWorker(t, &config, engine, db, 0, &cfg, &vmConfig)
 	defer w.close()
 	if enableTxDAG {
-		w.chain.SetupTxDAGGeneration()
+		w.chain.SetupTxDAGGeneration(false)
 	}
 
 	// Ignore empty commit here for less noise.

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -160,7 +160,7 @@ func (t *BlockTest) Run(snapshotter bool, scheme string, tracer vm.EVMLogger, en
 	}
 	defer chain.Stop()
 	if enableTxDAG {
-		chain.SetupTxDAGGeneration()
+		chain.SetupTxDAGGeneration(false)
 	}
 
 	validBlocks, err := t.insertBlocks(chain)


### PR DESCRIPTION
### Description

This PR will integrate stateless into TxDAG generation, it aims to optimize the performance of witness generation, and merge rw record, witness collection with TxDAG.

This PR will be based on the PR https://github.com/bnb-chain/op-geth/pull/287.

When `--parallel.txdagwitnessgen` is enabled, read-only states will no longer be submitted to the trie prefetcher. Instead, txdag will be queried asynchronously, but the original parallel processing logic will still be retained for states reading caused by writes.

### Example

Add these parameters to geth:
```bash
--selfstateless.validate --parallel.txdag --parallel.txdagwitnessgen
```
`--parallel.txdag` will enable the TxDAG generation feature, while parallel.txdagsenderpriv specifies the private key of the sender for the transaction into which the generated TxDAG data is inserted.

### Changes

Notable changes:
* feat: support generate witness in txdag async process;
* ...
