### PR TITLE
fix: fix concurrent access witness panic

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1100,6 +1100,7 @@ func (s *StateDB) AccountsIntermediateRoot() {
 			}
 		}
 	}
+	wg.Wait()
 	// If witness building is enabled, gather all the read-only accesses
 	if s.witness != nil {
 		// Pull in anything that has been accessed before destruction
@@ -1130,9 +1131,7 @@ func (s *StateDB) AccountsIntermediateRoot() {
 				s.witness.AddState(obj.trie.Witness())
 			}
 		}
-
 	}
-	wg.Wait()
 }
 
 func (s *StateDB) StateIntermediateRoot() common.Hash {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1100,7 +1100,6 @@ func (s *StateDB) AccountsIntermediateRoot() {
 			}
 		}
 	}
-	wg.Wait()
 	// If witness building is enabled, gather all the read-only accesses
 	if s.witness != nil {
 		// Pull in anything that has been accessed before destruction
@@ -1125,6 +1124,9 @@ func (s *StateDB) AccountsIntermediateRoot() {
 			if len(obj.originStorage) == 0 {
 				continue
 			}
+			if _, ok := s.stateObjectsPending[obj.address]; ok {
+				continue
+			}
 			if trie := obj.getPrefetchedTrie(); trie != nil {
 				s.witness.AddState(trie.Witness())
 			} else if obj.trie != nil {
@@ -1132,6 +1134,7 @@ func (s *StateDB) AccountsIntermediateRoot() {
 			}
 		}
 	}
+	wg.Wait()
 }
 
 func (s *StateDB) StateIntermediateRoot() common.Hash {


### PR DESCRIPTION
### Description

Fix concurrent access witness panic.

### Rationale

https://github.com/bnb-chain/op-geth/blob/1fde7613d115932239a16b9fc7b2f06ceea9df32/core/state/statedb.go#L1085
Update the same trie hash with the https://github.com/bnb-chain/op-geth/blob/1fde7613d115932239a16b9fc7b2f06ceea9df32/core/state/statedb.go#L1128.

line1128 no need to collect updated-trie which has collected in line1090.

### Example

N/A.

### Changes

Notable changes:
* witness generater workflow.
