### PR TITLE
fix: fix stateless leak witness bug

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -356,7 +356,7 @@ func (s *stateObject) updateTrie() (Trie, error) {
 
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
-		if s.db.witness != nil || len(s.originStorage) == 0 {
+		if s.db.witness == nil || len(s.originStorage) == 0 {
 			log.Info("debug witness, updateTrie, no pending/origin storage", "addr", s.address)
 			return s.trie, nil
 		}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -352,7 +352,7 @@ func (s *stateObject) finaliseRWSet() {
 // storage change at all.
 func (s *stateObject) updateTrie() (Trie, error) {
 	// Make sure all dirty slots are finalized into the pending storage area
-	s.finalise(false)
+	// s.finalise(false)
 
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
@@ -403,12 +403,20 @@ func (s *stateObject) updateTrie() (Trie, error) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		// Perform trie updates before deletions.  This prevents resolution of unnecessary trie nodes
+		//  in circumstances similar to the following:
+		//
+		// Consider nodes `A` and `B` who share the same full node parent `P` and have no other siblings.
+		// During the execution of a block:
+		// - `A` is deleted,
+		// - `C` is created, and also shares the parent `P`.
+		// If the deletion is handled first, then `P` would be left with only one child, thus collapsed
+		// into a shortnode. This requires `B` to be resolved from disk.
+		// Whereas if the created node is handled first, then the collapse is avoided, and `B` is not resolved.
+		var deletions []common.Hash
 		for key, value := range dirtyStorage {
 			if len(value) == 0 {
-				if err := tr.DeleteStorage(s.address, key[:]); err != nil {
-					s.db.setError(err)
-				}
-				s.db.StorageDeleted += 1
+				deletions = append(deletions, key)
 			} else {
 				if err := tr.UpdateStorage(s.address, key[:], value); err != nil {
 					s.db.setError(err)
@@ -417,6 +425,12 @@ func (s *stateObject) updateTrie() (Trie, error) {
 			}
 			// Cache the items for preloading
 			usedStorage = append(usedStorage, key)
+		}
+		for _, key := range deletions {
+			if err := tr.DeleteStorage(s.address, key[:]); err != nil {
+				s.db.setError(err)
+			}
+			s.db.StorageDeleted += 1
 		}
 	}()
 	// If state snapshotting is active, cache the data til commit

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -352,11 +352,14 @@ func (s *stateObject) finaliseRWSet() {
 // storage change at all.
 func (s *stateObject) updateTrie() (Trie, error) {
 	// Make sure all dirty slots are finalized into the pending storage area
-	// s.finalise(false)
+	s.finalise(false)
 
 	// Short circuit if nothing changed, don't bother with hashing anything
 	if len(s.pendingStorage) == 0 {
-		return s.trie, nil
+		if s.db.witness != nil || len(s.originStorage) == 0 {
+			log.Info("debug witness, updateTrie, no pending/origin storage", "addr", s.address)
+			return s.trie, nil
+		}
 	}
 	// Track the amount of time wasted on updating the storage trie
 	if metrics.EnabledExpensive {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -409,6 +409,9 @@ func (s *StateDB) GetCode(addr common.Address) []byte {
 	}
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		if s.witness != nil {
+			s.witness.AddCode(stateObject.Code())
+		}
 		return stateObject.Code()
 	}
 	return nil
@@ -420,6 +423,9 @@ func (s *StateDB) GetCodeSize(addr common.Address) int {
 	}
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
+		if s.witness != nil {
+			s.witness.AddCode(stateObject.Code())
+		}
 		return stateObject.CodeSize()
 	}
 	return 0
@@ -1155,15 +1161,29 @@ func (s *StateDB) StateIntermediateRoot() common.Hash {
 	}
 
 	usedAddrs := make([]common.Address, 0, len(s.stateObjectsPending))
+	// Perform updates before deletions.  This prevents resolution of unnecessary trie nodes
+	// in circumstances similar to the following:
+	//
+	// Consider nodes `A` and `B` who share the same full node parent `P` and have no other siblings.
+	// During the execution of a block:
+	// - `A` self-destructs,
+	// - `C` is created, and also shares the parent `P`.
+	// If the self-destruct is handled first, then `P` would be left with only one child, thus collapsed
+	// into a shortnode. This requires `B` to be resolved from disk.
+	// Whereas if the created node is handled first, then the collapse is avoided, and `B` is not resolved.
+	var deletedAddrs []common.Address
 	for addr := range s.stateObjectsPending {
 		if obj := s.stateObjects[addr]; obj.deleted {
-			s.deleteStateObject(obj)
-			s.AccountDeleted += 1
+			deletedAddrs = append(deletedAddrs, obj.address)
 		} else {
 			s.updateStateObject(obj)
 			s.AccountUpdated += 1
 		}
 		usedAddrs = append(usedAddrs, addr) // Copy needed for closure
+	}
+	for _, deletedAddr := range deletedAddrs {
+		s.deleteStateObject(s.stateObjects[deletedAddr])
+		s.AccountDeleted += 1
 	}
 	if s.prefetcher != nil {
 		s.prefetcher.used(common.Hash{}, s.originalRoot, usedAddrs, nil)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -251,9 +251,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		// Initialise a new contract and set the code that is to be used by the EVM.
 		// The contract is a scoped environment for this execution context only.
 		code := evm.StateDB.GetCode(addr)
-		if witness := evm.StateDB.Witness(); witness != nil {
-			witness.AddCode(code)
-		}
 		if len(code) == 0 {
 			ret, err = nil, nil // gas is unchanged
 		} else {
@@ -334,9 +331,6 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 			code := evm.StateDB.GetCode(addrCopy)
 			codeHash := evm.StateDB.GetCodeHash(addrCopy)
 			contract.optimized, code = tryGetOptimizedCode(evm, codeHash, code)
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(code)
-			}
 			contract.SetCallCode(&addrCopy, codeHash, code)
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
@@ -346,9 +340,6 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 			// The contract is a scoped environment for this execution context only.
 			contract := NewContract(caller, AccountRef(caller.Address()), value, gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(evm.StateDB.GetCode(addrCopy))
-			}
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		}
@@ -398,9 +389,6 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 			codeHash := evm.StateDB.GetCodeHash(addrCopy)
 			contract.optimized, code = tryGetOptimizedCode(evm, codeHash, code)
 			contract.SetCallCode(&addrCopy, codeHash, code)
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(code)
-			}
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		} else {
@@ -408,9 +396,6 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 			// Initialise a new contract and make initialise the delegate values
 			contract := NewContract(caller, AccountRef(caller.Address()), nil, gas).AsDelegate()
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(evm.StateDB.GetCode(addrCopy))
-			}
 			ret, err = evm.interpreter.Run(contract, input, false)
 			gas = contract.Gas
 		}
@@ -469,9 +454,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 			codeHash := evm.StateDB.GetCodeHash(addrCopy)
 			contract.optimized, code = tryGetOptimizedCode(evm, codeHash, code)
 			contract.SetCallCode(&addrCopy, codeHash, code)
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(code)
-			}
 			// When an error was returned by the EVM or when setting the creation code
 			// above we revert to the snapshot and consume any gas remaining. Additionally
 			// when we're in Homestead this also counts for code storage gas errors.
@@ -486,9 +468,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 			// The contract is a scoped environment for this execution context only.
 			contract := NewContract(caller, AccountRef(addrCopy), new(uint256.Int), gas)
 			contract.SetCallCode(&addrCopy, evm.StateDB.GetCodeHash(addrCopy), evm.StateDB.GetCode(addrCopy))
-			if witness := evm.StateDB.Witness(); witness != nil {
-				witness.AddCode(evm.StateDB.GetCode(addrCopy))
-			}
 			// When an error was returned by the EVM or when setting the creation code
 			// above we revert to the snapshot and consume any gas remaining. Additionally
 			// when we're in Homestead this also counts for code storage gas errors.

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -341,10 +341,6 @@ func opReturnDataCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeConte
 
 func opExtCodeSize(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	slot := scope.Stack.peek()
-	address := slot.Bytes20()
-	if witness := interpreter.evm.StateDB.Witness(); witness != nil {
-		witness.AddCode(interpreter.evm.StateDB.GetCode(address))
-	}
 	slot.SetUint64(uint64(interpreter.evm.StateDB.GetCodeSize(slot.Bytes20())))
 	return nil, nil
 }
@@ -387,9 +383,6 @@ func opExtCodeCopy(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext)
 	}
 	addr := common.Address(a.Bytes20())
 	code := interpreter.evm.StateDB.GetCode(addr)
-	if witness := interpreter.evm.StateDB.Witness(); witness != nil {
-		witness.AddCode(code)
-	}
 	codeCopy := getData(code, uint64CodeOffset, length.Uint64())
 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -17,7 +17,11 @@
 package vm
 
 import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -240,7 +244,6 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// execute the operation
 		res, err = operation.execute(&pc, in, callContext)
 		if err != nil {
-			log.Info("debug witness, failed to operation execute", "error", err)
 			break
 		}
 		pc++
@@ -248,6 +251,35 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 
 	if err == errStopToken {
 		err = nil // clear stop token error
+	}
+
+	if err != nil {
+		// Convert ret to readable error message if it's a revert
+		var errorMsg string
+		if len(res) >= 4 && hexutil.Encode(res[:4]) == "0x08c379a0" {
+			// Try to decode the revert reason
+			errorAbi, _ := abi.JSON(strings.NewReader(`[{"name":"Error","type":"function","inputs":[{"name":"message","type":"string"}]}]`))
+			unpacked, err := errorAbi.Unpack("Error", res[4:])
+			if err == nil && len(unpacked) > 0 {
+				errorMsg = unpacked[0].(string)
+			}
+		}
+
+		// If we couldn't decode the revert reason, use the raw hex
+		if errorMsg == "" {
+			errorMsg = hexutil.Encode(res)
+		}
+
+		log.Info("debug witness, failed to operation execute",
+			"error", err,
+			"op", op,
+			"pc", pc,
+			"res", res,
+			"revert_reason", errorMsg,
+			"raw_return", hexutil.Encode(res),
+			"contract_addr", contract.Address(),
+			"contract_code_hash", contract.CodeHash,
+		)
 	}
 
 	return res, err


### PR DESCRIPTION
### Description

Fix stateless leak witness bug.

### Rationale

Merged https://github.com/ethereum/go-ethereum/pull/30698, https://github.com/ethereum/go-ethereum/pull/29201, which may affect witness correctness. 

And fix

```
    if len(s.pendingStorage) == 0 {
		return s.trie, nil
    }
```

to
```
    if len(s.pendingStorage) == 0 {
		if s.db.witness == nil || len(s.originStorage) == 0 {
			log.Info("debug witness, updateTrie, no pending/origin storage", "addr", s.address)
			return s.trie, nil
		}
    }
```

### Example

N/A.

### Changes

Notable changes:
* witness related code.
