### PR TITLE
fix: solve proof keeper incorrect block truncation

### DIFF
--- a/core/proof_keeper.go
+++ b/core/proof_keeper.go
@@ -470,7 +470,7 @@ func (keeper *ProofKeeper) truncateProofDataRecordHeadIfNeeded(blockID uint64) {
 			keeper.proofDataDB.Reset()
 			return
 		}
-		if proof.BlockID < blockID {
+		if proof.BlockID <= blockID {
 			truncateProofID = proof.ProofID
 			break
 		}


### PR DESCRIPTION
### Description

`ProofKeeper` persistently stores proof data in the ancientDB, ensuring long-term availability of proofs for the address `0x4200000000000000000000000000000000000016`. This prevents scenarios where a sequencer failure or data loss would leave the proposer without the required historical proofs, thereby avoiding user withdrawal failures.

However, `ProofKeeper` cannot work well due to the internal bug, this pr solves the bug.

### Rationale

This pr modifies the logic in `truncateProofDataRecordHeadIfNeeded` to truncate proof data record correctly. After fixing, `ProofKeeper` can provide long time proof data.

### Example

N/A

### Changes

Notable changes:
* N/A
