### PR TITLE
fix: adjust MaxBundleAliveBlock to 240

### DIFF
--- a/core/types/bundle.go
+++ b/core/types/bundle.go
@@ -10,9 +10,9 @@ import (
 )
 
 const (
-	// MaxBundleAliveBlock is the max alive block for bundle
+	// MaxBundleAliveBlock is the max alive block for bundle.
 	MaxBundleAliveBlock = 240
-	// MaxBundleAliveTime is the max alive time for bundle
+	// MaxBundleAliveTime is the max alive time for bundle.
 	MaxBundleAliveTime = 60 // second
 )
 

--- a/core/types/bundle.go
+++ b/core/types/bundle.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// MaxBundleAliveBlock is the max alive block for bundle
-	MaxBundleAliveBlock = 60
+	MaxBundleAliveBlock = 240
 	// MaxBundleAliveTime is the max alive time for bundle
 	MaxBundleAliveTime = 60 // second
 )


### PR DESCRIPTION
### Description

Adjust `MaxBundleAliveBlock` to 240 for current 250ms block time.

### Rationale

N/A

### Example

N/A

### Changes

Notable changes:
* N/A
