### PR TITLE
fix: preserve boundary-aligned start block during nodebufferlist recovery

### DIFF
--- a/triedb/pathdb/nodebufferlist.go
+++ b/triedb/pathdb/nodebufferlist.go
@@ -262,7 +262,13 @@ func (nf *nodebufferlist) readStateHistory(freezer *rawdb.ResettableFreezer, sta
 
 func (nf *nodebufferlist) createBlockInterval(startBlock, endBlock uint64) [][]uint64 {
 	var intervalBoundaries [][]uint64
+	// Intervals are inclusive on both ends, so an already aligned startBlock has to
+	// stay the first interval end. Advancing past it would leave no recovered layer
+	// ending on that boundary, making the block unaddressable as a proposed block.
 	firstIntervalEnd := startBlock + nf.dlInMd - (startBlock % nf.dlInMd)
+	if startBlock%nf.dlInMd == 0 {
+		firstIntervalEnd = startBlock
+	}
 	if endBlock < firstIntervalEnd {
 		firstIntervalEnd = endBlock
 	}

--- a/triedb/pathdb/nodebufferlist_test.go
+++ b/triedb/pathdb/nodebufferlist_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package pathdb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestCreateBlockIntervalBoundaryStartPreservesProposerBlock ensures that a
+// recovery starting exactly on a dlInMd boundary yields a layer ending on that
+// boundary, which proposedBlockReader requires to serve the block's state.
+func TestCreateBlockIntervalBoundaryStartPreservesProposerBlock(t *testing.T) {
+	nf := &nodebufferlist{dlInMd: 1800}
+
+	got := nf.createBlockInterval(3600, 7200)
+	want := [][]uint64{
+		{5401, 7200},
+		{3601, 5400},
+		{3600, 3600},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("createBlockInterval(3600, 7200) = %v, want %v", got, want)
+	}
+}
+
+func TestCreateBlockIntervalNonAlignedStart(t *testing.T) {
+	nf := &nodebufferlist{dlInMd: 1800}
+
+	got := nf.createBlockInterval(3601, 7200)
+	want := [][]uint64{
+		{5401, 7200},
+		{3601, 5400},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("createBlockInterval(3601, 7200) = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
### Description

`createBlockInterval()` splits the recovered ancient-history range into the block intervals that back the reconstructed multiDifflayers. Both ends of an interval are inclusive, but the first interval end was always computed as `startBlock + dlInMd - (startBlock % dlInMd)`, which advances to the *next* boundary when `startBlock` is already aligned to `dlInMd`. This PR keeps an aligned `startBlock` as the first interval end. Non-aligned starts are unaffected.

### Rationale

When the recovery range starts exactly on a `dlInMd` boundary, no reconstructed layer ends on that boundary. `proposedBlockReader()` only accepts a layer whose `buffer.block % wpBlocks == 0`, so the state of that proposal block becomes unreachable through the `Database.Reader()` fallback and `eth_getProof` for it fails even though the state history needed to rebuild it was present in the freezer.

With the defaults (`wpBlocks = 3600`, `dlInMd = 1800`), a range starting at block `3600` was rebuilt as one layer ending at `5400`. Since `5400 % 3600 != 0`, that layer served no proposal block at all, and block `3600` was lost as a readable checkpoint.

This is a narrow path: a normal flush keeps `persistID` on a `dlInMd` multiple (`flush()` only merges complete layers, guarded by `nf.count <= nf.rsevMdNum`), so `startBlock` is usually `boundary + 1` and both old and new code agree. An aligned start requires `revert()` — which merges the in-progress head layer and so can leave `persistID` on an arbitrary block — followed by a flush and an unclean shutdown that drops the journal.

### Example

`dlInMd = 1800`, recovering blocks `3600..7200`:

    before: [[5401 7200] [3600 5400]]           // nothing ends at 3600
    after:  [[5401 7200] [3601 5400] [3600 3600]]

A non-aligned start is unchanged, `3601..7200` still yields:

    [[5401 7200] [3601 5400]]

### Changes

Notable changes:
* `triedb/pathdb/nodebufferlist.go`: keep an already aligned `startBlock` as the first inclusive interval end in `createBlockInterval()`
* `triedb/pathdb/nodebufferlist_test.go`: cover the aligned-start boundary and assert that non-aligned starts keep their existing split